### PR TITLE
Introduce Custom Read Model for Query Results

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
-  Max: 150
+  Enabled: false
 
 Style/FrozenStringLiteralComment:
   Enabled: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     simple_query (0.1.0)
-      activerecord (>= 5.0, < 7.1)
+      activerecord (>= 5.0, < 7.2)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,32 @@ User.simple_query
     .lazy_execute
 ```
 
+## Custom Read Models
+By default, SimpleQuery returns results as `Struct` objects for maximum speed. However, you can also define a lightweight model class for more explicit attribute handling or custom logic.
+
+**Create a read model** inheriting from `SimpleQuery::ReadModel`:
+```ruby
+class MyUserReadModel < SimpleQuery::ReadModel
+  attribute :identifier, column: :id
+  attribute :full_name,  column: :name
+end
+```
+
+**Map query results** to your read model:
+```ruby
+results = User.simple_query
+              .select("users.id AS id", "users.name AS name")
+              .where(active: true)
+              .map_to(MyUserReadModel)
+              .execute
+
+results.each do |user|
+  puts user.identifier    # => user.id from the DB
+  puts user.full_name     # => user.name from the DB
+end
+```
+This custom read model approach provides more clarity or domain-specific logic while still being faster than typical ActiveRecord instantiation.
+
 ## Features
 
 - Efficient query building
@@ -68,6 +94,7 @@ User.simple_query
 - LIMIT and OFFSET
 - ORDER BY clause
 - Subqueries
+- Optional custom Read models
 
 ## Performance
 
@@ -75,9 +102,12 @@ SimpleQuery is designed to potentially outperform standard ActiveRecord queries 
 
 ```
 🚀 Performance Results (100,000 records):
-ActiveRecord Query:        0.43343 seconds
-SimpleQuery Execution:      0.06186 seconds
+ActiveRecord Query:                  0.47441 seconds
+SimpleQuery Execution (Struct):      0.05346 seconds
+SimpleQuery Execution (Read model):  0.14408 seconds
 ```
+- The **Struct-based** approach is the fastest. 
+- The **Read model** approach is still significantly faster than ActiveRecord, while letting you define custom logic or domain-specific attributes.
 
 ## Development
 

--- a/lib/simple_query.rb
+++ b/lib/simple_query.rb
@@ -2,6 +2,7 @@
 
 require "active_record"
 require "simple_query/builder"
+require "simple_query/read_model"
 
 module SimpleQuery
   extend ActiveSupport::Concern

--- a/lib/simple_query/read_model.rb
+++ b/lib/simple_query/read_model.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SimpleQuery
+  class ReadModel
+    def self.attribute(attr_name, column: attr_name)
+      @attributes ||= {}
+      @attributes[attr_name] = column.to_s
+      attr_reader attr_name
+    end
+
+    def self.attributes
+      @attributes || {}
+    end
+
+    def self.build_from_row(row_hash)
+      obj = allocate
+      attributes.each do |attr_name, column_name|
+        obj.instance_variable_set(:"@#{attr_name}", row_hash[column_name])
+      end
+      obj
+    end
+
+    def initialize; end
+  end
+end

--- a/simple_query.gemspec
+++ b/simple_query.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["lib/**/*", "LICENSE.txt", "README.md"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 5.0", "< 7.1"
+  spec.add_dependency "activerecord", ">= 5.0", "< 7.2"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/simple_query/read_model_spec.rb
+++ b/spec/simple_query/read_model_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SimpleQuery::ReadModel do
+  describe ".attribute" do
+    it "defines attribute readers (no writers)" do
+      model = TestReadModel.build_from_row({})
+
+      expect(model).to respond_to(:foo)
+      expect(model).to respond_to(:bar)
+      expect(model).not_to respond_to(:foo=)
+      expect(model).not_to respond_to(:bar=)
+    end
+
+    it "maps custom column names to attributes" do
+      row_hash = { "baz" => "SomeBarValue" }
+      model = TestReadModel.build_from_row(row_hash)
+      expect(model.bar).to eq("SomeBarValue")
+    end
+  end
+
+  describe ".build_from_row" do
+    it "sets instance variables directly from the row hash" do
+      row_hash = { "foo" => "FooValue", "baz" => "BarValue" }
+      model = TestReadModel.build_from_row(row_hash)
+      expect(model.foo).to eq("FooValue")
+      expect(model.bar).to eq("BarValue")
+    end
+
+    it "handles missing keys gracefully by leaving attributes as nil" do
+      row_hash = { "foo" => "OnlyFoo" }
+      model = TestReadModel.build_from_row(row_hash)
+      expect(model.foo).to eq("OnlyFoo")
+      expect(model.bar).to be_nil
+    end
+  end
+
+  describe ".attributes" do
+    it "returns a hash of defined attributes and their column mappings" do
+      expected = { foo: "foo", bar: "baz" }
+      expect(TestReadModel.attributes).to eq(expected)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,8 @@ require "support/models/company"
 require "support/models/project"
 require "support/models/team"
 require "support/models/user"
+require "support/read_models/my_user_read_model"
+require "support/read_models/test_read_model"
 
 RSpec.configure do |config|
   config.before(:suite) do

--- a/spec/support/read_models/my_user_read_model.rb
+++ b/spec/support/read_models/my_user_read_model.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class MyUserReadModel < SimpleQuery::ReadModel
+  attribute :identifier, column: "id"
+  attribute :full_name,  column: "name"
+
+  def admin?
+    full_name == "Admin"
+  end
+end

--- a/spec/support/read_models/test_read_model.rb
+++ b/spec/support/read_models/test_read_model.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class TestReadModel < SimpleQuery::ReadModel
+  attribute :foo
+  attribute :bar, column: :baz
+end


### PR DESCRIPTION
This pull request introduces a custom read model feature for SimpleQuery, enhancing how query results are mapped and returned. Instead of always returning anonymous `Struct` objects, developers can now define lightweight classes that:

- Map columns to attributes via a DSL (`attribute :foo, column: :bar`)
- Provide domain-specific naming and (optionally) custom logic
- Leverage direct instance variable assignment for **high performance**

### Key Changes

1. **Read Model Base Class**

- Added a new `SimpleQuery::ReadModel` base class.
- Supports a DSL for defining attributes and corresponding database column names.
- Utilizes `build_from_row` to avoid overhead from setter methods and initialization calls.

2. **Builder Integration**

- Introduced a method (e.g., `map_to(MyReadModel)`) in the Builder class that lets you opt into using the custom read model instead of `Struct` objects.
- Ensures large datasets can be handled efficiently thanks to minimal per-record overhead.

3. **Optimized Instantiation**

- Direct `instance_variable_set` usage avoids method call overhead when mapping each row to a read model object.
- Benchmarks show it remains significantly faster than ActiveRecord instantiation while allowing for lightweight object structures.

4. **Updated Documentation**

- README now includes instructions on creating custom read models and using `map_to`.
- Added performance benchmarks comparing:
   -   ActiveRecord queries
   -   SimpleQuery with Struct
   -   SimpleQuery with custom read model

5. **Comprehensive Testing**

- New unit tests cover the read model’s behavior: attribute definitions, column mapping, missing keys, etc.
- Integration tests confirm the builder and read model work seamlessly to produce correct results in large and complex queries.