### PR TITLE
refactor: Extract where logic into dedicated WhereClause class

### DIFF
--- a/lib/simple_query.rb
+++ b/lib/simple_query.rb
@@ -2,6 +2,7 @@
 
 require "active_record"
 require "simple_query/builder"
+require "simple_query/where_clause"
 require "simple_query/read_model"
 
 module SimpleQuery

--- a/lib/simple_query/builder.rb
+++ b/lib/simple_query/builder.rb
@@ -8,7 +8,7 @@ module SimpleQuery
       @model = source
       @arel_table = @model.arel_table
       @selects = []
-      @wheres = []
+      @wheres = WhereClause.new(@arel_table)
       @joins = []
       @orders = []
       @limits = nil
@@ -27,7 +27,7 @@ module SimpleQuery
     end
 
     def where(condition)
-      @wheres.concat(parse_where_condition(condition))
+      @wheres.add(condition)
       reset_query
       self
     end
@@ -182,7 +182,8 @@ module SimpleQuery
     end
 
     def apply_where_conditions
-      @query.where(@wheres.inject(&:and)) if @wheres.any?
+      condition = @wheres.to_arel
+      @query.where(condition) if condition
     end
 
     def apply_joins

--- a/lib/simple_query/where_clause.rb
+++ b/lib/simple_query/where_clause.rb
@@ -16,6 +16,7 @@ module SimpleQuery
 
     def to_arel
       return nil if @conditions.empty?
+
       @conditions.inject do |combined, current|
         combined.and(current)
       end

--- a/lib/simple_query/where_clause.rb
+++ b/lib/simple_query/where_clause.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module SimpleQuery
+  class WhereClause
+    attr_reader :conditions
+
+    def initialize(table)
+      @table = table
+      @conditions = []
+    end
+
+    def add(condition)
+      parsed_conditions = parse_condition(condition)
+      @conditions.concat(parsed_conditions)
+    end
+
+    def to_arel
+      return nil if @conditions.empty?
+      @conditions.inject do |combined, current|
+        combined.and(current)
+      end
+    end
+
+    private
+
+    def parse_condition(condition)
+      case condition
+      when Hash
+        condition.map { |field, value| @table[field].eq(value) }
+      when Arel::Nodes::Node
+        [condition]
+      else
+        [Arel.sql(condition.to_s)]
+      end
+    end
+  end
+end

--- a/spec/simple_query/where_clause_spec.rb
+++ b/spec/simple_query/where_clause_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SimpleQuery::WhereClause do
+  let(:users_table) { Arel::Table.new(:users) }
+  let(:where_clause) { described_class.new(users_table) }
+
+  describe "#add" do
+    it "adds a simple equality condition from a hash" do
+      where_clause.add(name: "Jane")
+      expect(where_clause.conditions.size).to eq(1)
+    end
+
+    it "adds multiple conditions from a hash" do
+      where_clause.add(name: "Jane", email: "jane@example.com")
+      expect(where_clause.conditions.size).to eq(2)
+    end
+
+    it "handles a single Arel::Nodes::Node" do
+      condition_node = users_table[:active].eq(true)
+      where_clause.add(condition_node)
+      expect(where_clause.conditions.size).to eq(1)
+      expect(where_clause.conditions.first).to eq(condition_node)
+    end
+
+    it "handles a string" do
+      where_clause.add("users.deleted_at IS NULL")
+      expect(where_clause.conditions.size).to eq(1)
+    end
+  end
+
+  describe "#to_arel" do
+    it "returns a combined condition using AND" do
+      where_clause.add(active: true)
+      where_clause.add(admin: false)
+      combined = where_clause.to_arel
+
+      expect(combined).to be_a(Arel::Nodes::And)
+    end
+
+    it "returns nil when there are no conditions" do
+      expect(where_clause.to_arel).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This pull request refactors the existing where logic from `SimpleQuery::Builder` into a new `WhereClause` class. By isolating condition building and parsing responsibilities, we achieve:

1. Single Responsibility:

 - The Builder class is now more focused on orchestrating the overall query, while the new `WhereClause` class cleanly handles condition parsing and combination.

2. Improved Testability:

 - We can now write targeted unit tests against `WhereClause` to ensure it handles hashes, strings, and Arel nodes correctly, without needing the entire query-building context.

3. Future Extensibility:

 - Lays groundwork for advanced condition helpers (e.g., `.where_in`, `.where_not`) that can be added without complicating the main Builder logic.
 
4. Clean Integration:

- The Builder#where method delegates to `WhereClause`, preserving the existing public API while keeping the codebase simpler and more modular.

Overall, this refactoring makes SimpleQuery cleaner, easier to maintain, and better prepared for adding advanced querying features in the future.