### PR TITLE
feat: add config option to auto-include SimpleQuery into ActiveRecord::Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,30 @@ Or install it yourself as:
 gem install simple_query
 ```
 
+## Configuration
+
+By default, `SimpleQuery` does **not** automatically patch `ActiveRecord::Base`. You can **manually** include the module in individual models or in a global initializer:
+
+```ruby
+# Manual include (per model)
+class User < ActiveRecord::Base
+  include SimpleQuery
+end
+
+# or do it globally
+ActiveRecord::Base.include(SimpleQuery)
+```
+If you prefer a “just works” approach (i.e., every model has `.simple_query`), you can opt in:
+
+```ruby
+# config/initializers/simple_query.rb
+SimpleQuery.configure do |config|
+  config.auto_include_ar = true
+end
+```
+
+This tells SimpleQuery to automatically do `ActiveRecord::Base.include(SimpleQuery)` for you.
+
 ## Usage
 
 SimpleQuery offers an intuitive interface for building queries with joins, conditions, and aggregations. Here are some examples:
@@ -93,8 +117,9 @@ This custom read model approach provides more clarity or domain-specific logic w
 - Aggregations
 - LIMIT and OFFSET
 - ORDER BY clause
+- Having and Grouping
 - Subqueries
-- Optional custom Read models
+- Custom Read models
 
 ## Performance
 

--- a/lib/simple_query.rb
+++ b/lib/simple_query.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "active_record"
 require "active_support/concern"
+require "active_record"
 
 require_relative "simple_query/builder"
 require_relative "simple_query/read_model"
@@ -15,11 +15,30 @@ require_relative "simple_query/clauses/group_having_clause"
 module SimpleQuery
   extend ActiveSupport::Concern
 
+  class Configuration
+    attr_accessor :auto_include_ar
+
+    def initialize
+      @auto_include_ar = false
+    end
+  end
+
+  def self.configure
+    yield config
+    auto_include! if config.auto_include_ar
+  end
+
+  def self.config
+    @config ||= Configuration.new
+  end
+
+  def self.auto_include!
+    ActiveRecord::Base.include(SimpleQuery)
+  end
+
   included do
     def self.simple_query
       Builder.new(self)
     end
   end
 end
-
-ActiveRecord::Base.include SimpleQuery

--- a/spec/support/models/company.rb
+++ b/spec/support/models/company.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Company < ActiveRecord::Base
+  include SimpleQuery
+
   belongs_to :user
   has_many :projects
 

--- a/spec/support/models/project.rb
+++ b/spec/support/models/project.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Project < ActiveRecord::Base
+  include SimpleQuery
 end

--- a/spec/support/models/team.rb
+++ b/spec/support/models/team.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Team < ActiveRecord::Base
+  include SimpleQuery
 end

--- a/spec/support/models/user.rb
+++ b/spec/support/models/user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class User < ActiveRecord::Base
+  include SimpleQuery
+
   has_many :companies
   has_many :projects, through: :companies
   has_and_belongs_to_many :teams


### PR DESCRIPTION
This PR introduces an opt-in configuration setting for SimpleQuery that allows users to automatically include the SimpleQuery module in `ActiveRecord::Base`. By default, `SimpleQuery` remains unintrusive — developers must explicitly include the module where needed. With this auto-include feature, they can enable a “just works” approach for all ActiveRecord models.

### Key Changes

1. Configuration Class

- Added a `SimpleQuery.configure` method and a Configuration class storing user preferences.
- Introduced an `auto_include_ar` boolean attribute (default `false`).

2. Opt-In Monkey-Patching

- If `auto_include_ar` is set to `true`, `SimpleQuery` automatically calls `ActiveRecord::Base.include(SimpleQuery)` during configuration.
- For users who prefer selective usage, the default remains manual inclusion per model or globally in their own code.

3. Documentation

- Updated the README with examples showing both manual and auto-inclusion, ensuring developers can pick the approach that best fits their project.