### PR TITLE
gemspec update

### DIFF
--- a/simple_query.gemspec
+++ b/simple_query.gemspec
@@ -10,14 +10,14 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "A lightweight and efficient query builder for ActiveRecord."
   spec.description   = "SimpleQuery provides a flexible and performant way to construct complex database queries in Ruby on Rails applications. It offers an intuitive interface for building queries with joins, conditions, and aggregations, while potentially outperforming standard ActiveRecord queries on large datasets."
-  spec.homepage      = "https://oneruby.dev"
+  spec.homepage      = "https://github.com/kholdrex/simple_query"
   spec.license       = "MIT"
   spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata = {
     "homepage_uri" => spec.homepage,
     "source_code_uri" => "https://github.com/kholdrex/simple_query",
-    "changelog_uri" => "https://github.com/kholdrex/simple_query/blob/main/CHANGELOG.md"
+    "changelog_uri" => "https://github.com/kholdrex/simple_query/blob/master/CHANGELOG.md"
   }
 
   spec.files         = Dir["lib/**/*", "LICENSE.txt", "README.md"]


### PR DESCRIPTION
This pull request includes a small change to the `simple_query.gemspec` file. The change updates the homepage and changelog URIs to point to the correct GitHub repository.

* [`simple_query.gemspec`](diffhunk://#diff-cfe40c3172ac5e33522ebe24576a0ef7287290d1ce2c9a2f3c119799b60a5941L13-R20): Updated the `homepage` and `changelog_uri` to "https://github.com/kholdrex/simple_query" and "https://github.com/kholdrex/simple_query/blob/master/CHANGELOG.md" respectively.