### PR TITLE
ci: support ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
         ar-gemfile: ["activerecord7.0", "activerecord7.1", "activerecord7.2", "activerecord8.0"]
         exclude:
           # ActiveRecord 7.2 => requires Ruby >= 3.1


### PR DESCRIPTION
This pull request includes an update to the CI configuration to add support for Ruby 3.4.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL14-R14): Added Ruby 3.4 to the list of versions in the matrix for the CI jobs.