### PR TITLE
feat: add named scopes support to SimpleQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,48 @@ end
 ```
 This custom read model approach provides more clarity or domain-specific logic while still being faster than typical ActiveRecord instantiation.
 
+## Named Scopes
+SimpleQuery now supports named scopes, allowing you to reuse common query logic in a style similar to ActiveRecord’s built-in scopes. To define a scope, use the simple_scope class method in your model:
+```ruby
+class User < ActiveRecord::Base
+  include SimpleQuery
+
+  simple_scope :active do
+    where(active: true)
+  end
+
+  simple_scope :admins do
+    where(admin: true)
+  end
+
+  simple_scope :by_name do |name|
+    where(name: name)
+  end
+end
+```
+You can then chain these scopes seamlessly with the normal SimpleQuery DSL:
+
+```ruby
+# Parameterless scopes
+results = User.simple_query.active.admins.execute
+
+# Parameterized scope
+results = User.simple_query.by_name("Jane Doe").execute
+
+# Mixing scopes with other DSL calls
+results = User.simple_query
+              .by_name("John")
+              .active
+              .select(:id, :name)
+              .order(name: :asc)
+              .execute
+```
+### How It Works
+
+Each scope block (e.g. by_name) is evaluated in the context of the SimpleQuery builder, so you can call any DSL method (where, order, etc.) inside it.
+Parameterized scopes accept arguments — passed directly to the block (e.g. |name| above).
+Scopes return self, so you can chain multiple scopes or mix them with standard query methods.
+
 ## Features
 
 - Efficient query building
@@ -120,6 +162,7 @@ This custom read model approach provides more clarity or domain-specific logic w
 - Having and Grouping
 - Subqueries
 - Custom Read models
+- Named Scopes
 
 ## Performance
 

--- a/lib/simple_query.rb
+++ b/lib/simple_query.rb
@@ -36,6 +36,27 @@ module SimpleQuery
     ActiveRecord::Base.include(SimpleQuery)
   end
 
+  class_methods do
+    def _simple_scopes
+      @_simple_scopes ||= {}
+    end
+
+    # A reusable scope that can be applied to a SimpleQuery::Builder instance
+    # Example:
+    #   simple_scope :active do
+    #     where(active: true)
+    #   end
+    #
+    # Parameterized scope:
+    #   simple_scope :by_name do |name|
+    #     where(name: name)
+    #   end
+    #
+    def simple_scope(name, &block)
+      _simple_scopes[name.to_sym] = block
+    end
+  end
+
   included do
     def self.simple_query
       Builder.new(self)

--- a/lib/simple_query/builder.rb
+++ b/lib/simple_query/builder.rb
@@ -222,7 +222,7 @@ module SimpleQuery
     end
 
     def method_missing(method_name, *args, &block)
-      if scope_block = find_scope(method_name)
+      if (scope_block = find_scope(method_name))
         instance_exec(*args, &scope_block)
         self
       else
@@ -236,6 +236,7 @@ module SimpleQuery
 
     def find_scope(method_name)
       return unless model.respond_to?(:_simple_scopes)
+
       model._simple_scopes[method_name.to_sym]
     end
   end

--- a/lib/simple_query/builder.rb
+++ b/lib/simple_query/builder.rb
@@ -220,5 +220,23 @@ module SimpleQuery
         raise ArgumentError, "Unsupported select field type: #{field.class}"
       end
     end
+
+    def method_missing(method_name, *args, &block)
+      if scope_block = find_scope(method_name)
+        instance_exec(*args, &scope_block)
+        self
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      !!find_scope(method_name) || super
+    end
+
+    def find_scope(method_name)
+      return unless model.respond_to?(:_simple_scopes)
+      model._simple_scopes[method_name.to_sym]
+    end
   end
 end

--- a/spec/support/models/user.rb
+++ b/spec/support/models/user.rb
@@ -19,6 +19,18 @@ class User < ActiveRecord::Base
   scope :admins, -> { where(admin: true) }
   scope :recent, -> { where("created_at > ?", 30.days.ago) }
 
+  simple_scope :active do
+    where(active: true)
+  end
+
+  simple_scope :admins do
+    where(admin: true)
+  end
+
+  simple_scope :by_name do |name|
+    where(name: name)
+  end
+
   attr_accessor :temp_password
 
   def self.search(query)


### PR DESCRIPTION
This pull request introduces named scopes to SimpleQuery, enabling reusable, scope-like DSL blocks that can be chained just like ActiveRecord scopes — while retaining SimpleQuery’s streamlined performance benefits.

### Key Changes

**1. Scope Definition**
  - Added `simple_scope :name do ... end` class method in SimpleQuery.
  - Developers can define parameterless or parameterized scopes in their models, e.g.:
  ```ruby
    class User < ActiveRecord::Base
      include SimpleQuery
      
      simple_scope :active do
        where(active: true)
      end
    
      simple_scope :by_name do |name|
        where(name: name)
      end
    end

  ```
  - Internally, these scope definitions store blocks in a class-level hash.

**2. Scope Dispatch**

  - Updated `SimpleQuery::Builder` to use `method_missing` & r`espond_to_missing?` for scope calls (e.g. `.active`, `.by_name("Jane")`).
  - The scope block is `instance_exec’d` in the builder context, so DSL methods (`where`, `order`, etc.) can be called within the scope.
  - Returns `self` for fluent chaining with either more scopes or regular query methods.
