### PR TITLE
Support lambda-based and block-based simple_scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,13 @@ class User < ActiveRecord::Base
     where(admin: true)
   end
 
+  # Block-based scope with parameter
   simple_scope :by_name do |name|
     where(name: name)
   end
+
+  # Lambda-based scope with parameter
+  simple_scope :by_name, ->(name) { where(name: name) }
 end
 ```
 You can then chain these scopes seamlessly with the normal SimpleQuery DSL:

--- a/lib/simple_query.rb
+++ b/lib/simple_query.rb
@@ -41,19 +41,13 @@ module SimpleQuery
       @_simple_scopes ||= {}
     end
 
-    # A reusable scope that can be applied to a SimpleQuery::Builder instance
-    # Example:
-    #   simple_scope :active do
-    #     where(active: true)
-    #   end
-    #
-    # Parameterized scope:
-    #   simple_scope :by_name do |name|
-    #     where(name: name)
-    #   end
-    #
-    def simple_scope(name, &block)
-      _simple_scopes[name.to_sym] = block
+    def simple_scope(name, body = nil, &block)
+      raise ArgumentError, "Pass either a proc/lambda or a block, not both" if body && block_given?
+
+      scope_body = body || block
+      raise ArgumentError, "You must provide a block or a proc" unless scope_body
+
+      _simple_scopes[name.to_sym] = scope_body
     end
   end
 

--- a/simple_query.gemspec
+++ b/simple_query.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 1.21"
-  spec.add_development_dependency "sqlite3", "~> 2.1"
+  spec.add_development_dependency "sqlite3", "~> 1.5.0"
 end

--- a/simple_query.gemspec
+++ b/simple_query.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 1.21"
-  spec.add_development_dependency "sqlite3", "~> 1.5.0"
+  spec.add_development_dependency "sqlite3", "~> 2.1"
 end

--- a/spec/simple_query/builder_spec.rb
+++ b/spec/simple_query/builder_spec.rb
@@ -323,6 +323,11 @@ RSpec.describe SimpleQuery::Builder do
       results = User.simple_query.by_name("Nonexistent").execute
       expect(results).to be_empty
     end
+
+    it "supports lambda scopes with complex conditions" do
+      results = Company.simple_query.active.founded_after(2012).execute
+      expect(results.size).to eq(1)
+    end
   end
 
   describe "Performance Test" do

--- a/spec/support/models/company.rb
+++ b/spec/support/models/company.rb
@@ -16,6 +16,9 @@ class Company < ActiveRecord::Base
   scope :by_industry, ->(industry) { where(industry: industry) }
   scope :founded_after, ->(year) { where("founded_year > ?", year) }
 
+  simple_scope :active, -> { where(active: true) }
+  simple_scope :founded_after, ->(year) { where(["founded_year > ?", year]) }
+
   attr_accessor :temp_registration_code
 
   def age


### PR DESCRIPTION
This PR extends SimpleQuery’s `simple_scope` method to accept either a block or a lambda (proc), making scope definitions more flexible. Users can now define scopes like:

```ruby
# Block style
simple_scope :active do
  where(active: true)
end

# Lambda style
simple_scope :active, -> { where(active: true) }
```

### Key Changes

1. Flexible DSL

- Modified simple_scope to accept an optional body argument (`proc/lambda`) or a block.
- If both are provided, an `ArgumentError` is raised to avoid ambiguity.

2. Tests

- Updated specs to confirm we can define scopes with a `block (do ... end)` and a `lambda (-> { ... })`.
- Ensured parameter passing works for both styles (e.g., `simple_scope :by_name, ->(name) { where(name: name) }` or block style with `do |name| ... end)`.