### PR TITLE
feat: Implement extended join DSL for left, right, and full joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,12 @@ User.simple_query.select(:name, :email).where(active: true).execute
 ```
 
 Query with join
+
+SimpleQuery now supports **all major SQL join types** — including LEFT, RIGHT, and FULL — through the following DSL methods:
 ```ruby
 User.simple_query
-    .select(:name, :email)
-    .join(:users, :companies, foreign_key: :user_id, primary_key: :id)
-    .where(Company.arel_table[:name].eq("TechCorp"))
+    .left_join(:users, :companies, foreign_key: :user_id, primary_key: :id)
+    .select("users.name", "companies.name")
     .execute
 ```
 

--- a/lib/simple_query/builder.rb
+++ b/lib/simple_query/builder.rb
@@ -34,10 +34,22 @@ module SimpleQuery
       self
     end
 
-    def join(table1, table2, foreign_key:, primary_key:)
-      @joins.add(table1, table2, foreign_key: foreign_key, primary_key: primary_key)
+    def join(table1, table2, foreign_key:, primary_key:, type: :inner)
+      @joins.add(table1, table2, foreign_key: foreign_key, primary_key: primary_key, join_type: type)
       reset_query
       self
+    end
+
+    def left_join(table1, table2, foreign_key:, primary_key:)
+      join(table1, table2, foreign_key: foreign_key, primary_key: primary_key, type: :left)
+    end
+
+    def right_join(table1, table2, foreign_key:, primary_key:)
+      join(table1, table2, foreign_key: foreign_key, primary_key: primary_key, type: :right)
+    end
+
+    def full_join(table1, table2, foreign_key:, primary_key:)
+      join(table1, table2, foreign_key: foreign_key, primary_key: primary_key, type: :full)
     end
 
     def order(order_conditions)

--- a/lib/simple_query/clauses/join_clause.rb
+++ b/lib/simple_query/clauses/join_clause.rb
@@ -8,20 +8,37 @@ module SimpleQuery
       @joins = []
     end
 
-    def add(table1, table2, foreign_key:, primary_key:)
+    def add(table1, table2, foreign_key:, primary_key:, join_type: :inner)
       @joins << {
         table1: to_arel_table(table1),
         table2: to_arel_table(table2),
         foreign_key: foreign_key,
-        primary_key: primary_key
+        primary_key: primary_key,
+        type: join_type
       }
     end
 
     def apply_to(query)
-      @joins.each do |join|
-        query.join(join[:table2])
-             .on(join[:table2][join[:foreign_key]]
-                   .eq(join[:table1][join[:primary_key]]))
+      @joins.each do |join_def|
+        table1 = join_def[:table1]
+        table2 = join_def[:table2]
+        fk = join_def[:foreign_key]
+        pk = join_def[:primary_key]
+        type = join_def[:type]
+
+        join_class = case type
+                     when :left
+                       Arel::Nodes::OuterJoin
+                     when :right
+                       Arel::Nodes::RightOuterJoin
+                     when :full
+                       Arel::Nodes::FullOuterJoin
+                     else
+                       Arel::Nodes::InnerJoin
+                     end
+
+        condition = table2[fk].eq(table1[pk])
+        query.join(table2, join_class).on(condition)
       end
       query
     end

--- a/spec/simple_query/builder_spec.rb
+++ b/spec/simple_query/builder_spec.rb
@@ -68,6 +68,38 @@ RSpec.describe SimpleQuery::Builder do
       expect(result.first.name).to eq("Jane Doe")
     end
 
+    it "defaults to INNER JOIN if no type is provided" do
+      sql = query_object
+            .join(:users, :companies, foreign_key: :user_id, primary_key: :id)
+            .build_query
+            .to_sql
+      expect(sql).to match(/INNER JOIN "?companies"? ON "?companies"?\."?user_id"? = "?users"?\."?id"?/i)
+    end
+
+    it "supports left_join" do
+      sql = query_object
+            .left_join(:users, :companies, foreign_key: :user_id, primary_key: :id)
+            .build_query
+            .to_sql
+      expect(sql).to match(/LEFT OUTER JOIN "?companies"? ON "?companies"?\."?user_id"? = "?users"?\."?id"?/i)
+    end
+
+    it "supports right_join" do
+      sql = query_object
+            .right_join(:users, :companies, foreign_key: :user_id, primary_key: :id)
+            .build_query
+            .to_sql
+      expect(sql).to match(/RIGHT OUTER JOIN "?companies"? ON "?companies"?\."?user_id"? = "?users"?\."?id"?/i)
+    end
+
+    it "supports full_join" do
+      sql = query_object
+            .full_join(:users, :companies, foreign_key: :user_id, primary_key: :id)
+            .build_query
+            .to_sql
+      expect(sql).to match(/FULL OUTER JOIN "?companies"? ON "?companies"?\."?user_id"? = "?users"?\."?id"?/i)
+    end
+
     it "supports DISTINCT queries" do
       User.create(name: "Jane Doe", email: "jane2@example.com")
       result = User.simple_query


### PR DESCRIPTION
This pull request expands the existing `.join(...)` DSL in SimpleQuery to support all major join types — Left, Right, Full — while still defaulting to Inner. We add dedicated helper methods for each join type:

```ruby
.left_join(:table1, :table2, foreign_key:, primary_key:)
.right_join(:table1, :table2, foreign_key:, primary_key:)
.full_join(:table1, :table2, foreign_key:, primary_key:)
```

### Key Changes

1. `join(..., type: :something)`

  - The underlying `.join` method now accepts a `:type` option, mapping to Arel nodes (or raw SQL for some DBs).
  - By default, `type: :inner`, matching prior behavior.

2. Dedicated DSL Methods

  - `.left_join` calls `.join(..., type: :left)`
  - `.right_join` calls `.join(..., type: :right)`
  - `.full_join` calls `.join(..., type: :full)`

3. Tests

  - New specs confirm `Left/Right/Full` produce the correct “LEFT OUTER JOIN,” “RIGHT OUTER JOIN,” etc. in the final SQL string.
  - Ensures backward compatibility with existing “inner join” usage.