### PR TITLE
feat: introduce bulk_update for set-based updates in SimpleQuery

### DIFF
--- a/lib/simple_query.rb
+++ b/lib/simple_query.rb
@@ -11,6 +11,7 @@ require_relative "simple_query/clauses/order_clause"
 require_relative "simple_query/clauses/distinct_clause"
 require_relative "simple_query/clauses/limit_offset_clause"
 require_relative "simple_query/clauses/group_having_clause"
+require_relative "simple_query/clauses/set_clause"
 
 module SimpleQuery
   extend ActiveSupport::Concern

--- a/lib/simple_query/clauses/set_clause.rb
+++ b/lib/simple_query/clauses/set_clause.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SimpleQuery
+  class SetClause
+    def initialize(set_hash)
+      @set_hash = set_hash
+    end
+
+    def to_sql
+      @set_hash.map do |col, val|
+        "#{quote_column(col)} = #{quote_value(val)}"
+      end.join(", ")
+    end
+
+    private
+
+    def quote_column(col)
+      ActiveRecord::Base.connection.quote_column_name(col)
+    end
+
+    def quote_value(val)
+      ActiveRecord::Base.connection.quote(val)
+    end
+  end
+end

--- a/spec/simple_query/clauses/set_clause_spec.rb
+++ b/spec/simple_query/clauses/set_clause_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe SimpleQuery::SetClause do
+  describe "#to_sql" do
+    it "builds a simple set clause for strings and booleans" do
+      clause = described_class.new({ name: "Alice", active: false })
+      sql = clause.to_sql
+
+      expect(sql).to match(/"name" = 'Alice'/)
+      expect(sql).to match(/"active" = (0|false|'f')/i)
+      expect(sql).to include(",")
+    end
+
+    it "quotes column names with special chars" do
+      clause = described_class.new({ "weird column" => "val" })
+      sql = clause.to_sql
+
+      expect(sql).to match(/"weird column" = 'val'/)
+    end
+
+    it "handles multiple columns" do
+      clause = described_class.new(
+        status: "archived",
+        updated_at: Time.new(2025, 2, 15, 10, 30)
+      )
+      sql = clause.to_sql
+
+      expect(sql).to include("\"status\" = 'archived'")
+      expect(sql).to match(/"updated_at" = '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'/)
+      expect(sql).to include(",")
+    end
+
+    it "returns an empty string if set_hash is empty" do
+      clause = described_class.new({})
+      sql = clause.to_sql
+      expect(sql).to eq("")
+    end
+  end
+end

--- a/spec/simple_query/performance_spec.rb
+++ b/spec/simple_query/performance_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "benchmark"
+
+RSpec.describe SimpleQuery::Builder do
+  let(:query_object) { described_class.new(User) }
+
+  describe "Performance Test" do
+    before(:all) do
+      puts "\n⚡ Inserting 1000,000 test records for benchmarking..."
+      users = []
+      companies = []
+
+      1_000_000.times do |i|
+        users << {
+          name: "User#{i}",
+          email: "user#{i}@example.com",
+          first_name: "First#{i}",
+          last_name: "Last#{i}",
+          active: true,
+          admin: i % 100 == 0,
+          status: i % 3
+        }
+      end
+
+      User.insert_all(users)
+
+      users = User.pluck(:id)
+      users.each_with_index do |user_id, i|
+        companies << {
+          name: "Company#{i}",
+          user_id: user_id,
+          registration_number: "REG#{i}",
+          founded_year: 2000 + (i % 25),
+          industry: ["Tech", "Finance", "Healthcare", "Education"].sample,
+          active: true,
+          size: i % 3,
+          status: i % 3,
+          annual_revenue: rand(100_000..10_000_000)
+        }
+      end
+
+      Company.insert_all(companies)
+      puts "✅ Data Inserted!"
+    end
+
+    it "compares ActiveRecord vs SimpleQuery performance on a larger dataset" do
+      ar_time = Benchmark.realtime do
+        ActiveRecord::Base.uncached do
+          User.joins(:companies).where(active: true).to_a
+        end
+      end
+
+      simple_query_struct_time = Benchmark.realtime do
+        ActiveRecord::Base.uncached do
+          User.simple_query
+              .select(:name, :id)
+              .join(:users, :companies, foreign_key: :user_id, primary_key: :id)
+              .where(active: true).execute
+        end
+      end
+
+      simple_query_read_model_time = Benchmark.realtime do
+        ActiveRecord::Base.uncached do
+          User.simple_query
+              .select(:name, :id)
+              .join(:users, :companies, foreign_key: :user_id, primary_key: :id)
+              .where(active: true)
+              .map_to(MyUserReadModel)
+              .execute
+        end
+      end
+
+      puts "\n🚀 Performance Results (1000,000 records):"
+      puts "ActiveRecord Query:                  #{ar_time.round(5)} seconds"
+      puts "SimpleQuery Execution (Struct):      #{simple_query_struct_time.round(5)} seconds"
+      puts "SimpleQuery Execution (Read model):  #{simple_query_read_model_time.round(5)} seconds"
+
+      expect(simple_query_struct_time).to be < ar_time
+    end
+
+    it "compares update_all vs bulk_update on a large dataset" do
+      ar_time = Benchmark.realtime do
+        User.where(active: false).update_all(status: 1)
+      end
+
+      User.where(active: false).update_all(status: nil)
+
+      sq_time = Benchmark.realtime do
+        builder = SimpleQuery::Builder.new(User)
+        builder.where(active: false).bulk_update(set: { status: 2 })
+      end
+
+      puts "\n--- Bulk Update Benchmark ---"
+      puts "ActiveRecord update_all: #{ar_time.round(5)} seconds"
+      puts "SimpleQuery bulk_update: #{sq_time.round(5)} seconds"
+
+      rows_updated_ar = User.where(status: 2).count
+      rows_updated_sq = User.where(status: 2).count
+      expect(rows_updated_ar).to eq(rows_updated_sq)
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds a bulk_update method to SimpleQuery, letting developers update large subsets of records with a single SQL statement, bypassing row-by-row overhead. For example:

```ruby
User.simple_query
    .where(active: false)
    .bulk_update(set: { status: "archived", updated_at: Time.now })

```
Generates and executes:
```sql
UPDATE users
SET status = 'archived', updated_at = '2025-03-10 12:00:00'
WHERE active = 0

```