### PR TITLE
dependencies changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,13 +5,14 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "memory_profiler"
   gem "mysql2", "~> 0.5.2"
   gem "pg", "~> 1.5.0", ">= 1.5.6"
 
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.1.0")
+    gem "memory_profiler", "~> 1.1"
     gem "sqlite3", "~> 2.1"
   else
+    gem "memory_profiler", "~> 1.0.2"
     gem "sqlite3", "~> 1.5"
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,15 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 13.0"
-
-gem "rubocop", "~> 1.21"
-
 group :test do
   gem "memory_profiler"
   gem "mysql2", "~> 0.5.2"
   gem "pg", "~> 1.5.0", ">= 1.5.6"
+  gem "sqlite3", "~> 2.1"
+end
+
+group :development, :test do
+  gem "rake", "~> 13.0"
   gem "rspec", "~> 3.0"
+  gem "rubocop", "~> 1.21"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,12 @@ group :test do
   gem "memory_profiler"
   gem "mysql2", "~> 0.5.2"
   gem "pg", "~> 1.5.0", ">= 1.5.6"
-  gem "sqlite3", "~> 2.1"
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.1.0")
+    gem "sqlite3", "~> 2.1"
+  else
+    gem "sqlite3", "~> 1.5"
+  end
 end
 
 group :development, :test do


### PR DESCRIPTION

This pull request includes changes to the `Gemfile` to update and reorganize gem dependencies for better compatibility and environment-specific requirements.

### Gem dependency updates and reorganization:

* Moved `rake` and `rubocop` gems to a combined `:development, :test` group to ensure they are available in both development and test environments.
* Updated `memory_profiler` and `sqlite3` gems to use different versions based on the Ruby version being used, ensuring compatibility with Ruby versions 3.1.0 and above.
* Added the `rspec` gem to the `:development, :test` group for consistency and to ensure it is available in both environments.