### PR TITLE
fix: avoid stale result struct reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+## Unreleased
+
+### Fixed
+- Reusing a builder after changing the selected result shape now returns Struct rows with the correct members instead of reusing a stale Struct class.
+
 ## [0.5.0] - 2025-08-29
 
 ### Added

--- a/lib/simple_query/builder.rb
+++ b/lib/simple_query/builder.rb
@@ -23,7 +23,7 @@ module SimpleQuery
       @query_cache = {}
       @query_built = false
       @read_model_class = nil
-      @result_struct = nil
+      @result_structs = {}
     end
 
     def select(*fields)
@@ -340,7 +340,8 @@ module SimpleQuery
     end
 
     def result_struct(columns)
-      @result_struct ||= Struct.new(*columns.map(&:to_sym))
+      struct_key = columns.map(&:to_s)
+      @result_structs[struct_key] ||= Struct.new(*struct_key.map(&:to_sym))
     end
 
     def apply_distinct

--- a/spec/simple_query/builder_spec.rb
+++ b/spec/simple_query/builder_spec.rb
@@ -398,6 +398,46 @@ RSpec.describe SimpleQuery::Builder do
     end
   end
 
+  describe "result object shape caching" do
+    it "rebuilds Struct classes after a reused builder selects additional columns" do
+      builder = User.simple_query.select(:name).where(name: "Jane Doe")
+
+      first_result = builder.execute
+      expect(first_result.first).to respond_to(:name)
+      expect(first_result.first).not_to respond_to(:email)
+
+      second_result = builder.select(:email).execute
+      expect(second_result.first).to respond_to(:name)
+      expect(second_result.first).to respond_to(:email)
+      expect(second_result.first.email).to eq("jane@example.com")
+    end
+
+    it "rebuilds Struct classes after a reused builder adds aggregations" do
+      builder = Company.simple_query.select(:industry).group(:industry)
+
+      first_result = builder.execute
+      expect(first_result.first.members).to include(:industry)
+      expect(first_result.first.members).not_to include(:count)
+
+      second_result = builder.count.execute
+      expect(second_result.first.members).to include(:industry)
+      expect(second_result.first.members).to include(:count)
+    end
+
+    it "rebuilds Struct classes for lazy execution after a reused builder changes shape" do
+      builder = User.simple_query.select(:name).where(name: "Jane Doe")
+
+      first_result = builder.lazy_execute.first
+      expect(first_result).to respond_to(:name)
+      expect(first_result).not_to respond_to(:email)
+
+      second_result = builder.select(:email).lazy_execute.first
+      expect(second_result).to respond_to(:name)
+      expect(second_result).to respond_to(:email)
+      expect(second_result.email).to eq("jane@example.com")
+    end
+  end
+
   describe "query caching" do
     it "caches the SQL query" do
       expect(query_object.instance_variable_get(:@query_cache)).to be_empty


### PR DESCRIPTION
## Summary
- Fixes reused builders returning stale Struct result shapes after the selected columns or aggregation set changes.
- Caches generated Struct classes by the actual returned column list instead of reusing one Struct class for every shape.
- Adds regression coverage for eager execution, lazy execution, and aggregation shape changes.
- Adds an Unreleased changelog entry for the bug fix.

## Test Plan
- `ruby -Ilib -Ispec $(ruby -e 'puts Gem.bin_path("rspec-core", "rspec")') --format progress`
- `ruby -S rubocop`
- `gem build simple_query.gemspec`
- `git diff --check`
