### PR TITLE
ci: test ActiveRecord 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,20 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ["2.7", "3.0", "3.1", "3.2"]
-        ar-gemfile: ["activerecord7.0", "activerecord7.1", "activerecord7.2"]
+        ar-gemfile: ["activerecord7.0", "activerecord7.1", "activerecord7.2", "activerecord8.0"]
         exclude:
           # ActiveRecord 7.2 => requires Ruby >= 3.1
           - ruby-version: "2.7"
             ar-gemfile: "activerecord7.2"
           - ruby-version: "3.0"
             ar-gemfile: "activerecord7.2"
+          # ActiveRecord 8.0 => requires Ruby >= 3.2
+          - ruby-version: "2.7"
+            ar-gemfile: "activerecord8.0"
+          - ruby-version: "3.0"
+            ar-gemfile: "activerecord8.0"
+          - ruby-version: "3.1"
+            ar-gemfile: "activerecord8.0"
 
     steps:
       - uses: actions/checkout@v3
@@ -97,12 +104,19 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ["2.7", "3.0", "3.1", "3.2"]
-        ar-gemfile: ["activerecord7.0", "activerecord7.1", "activerecord7.2"]
+        ar-gemfile: ["activerecord7.0", "activerecord7.1", "activerecord7.2", "activerecord8.0"]
         exclude:
           - ruby-version: "2.7"
             ar-gemfile: "activerecord7.2"
           - ruby-version: "3.0"
             ar-gemfile: "activerecord7.2"
+          # ActiveRecord 8.0 => requires Ruby >= 3.2
+          - ruby-version: "2.7"
+            ar-gemfile: "activerecord8.0"
+          - ruby-version: "3.0"
+            ar-gemfile: "activerecord8.0"
+          - ruby-version: "3.1"
+            ar-gemfile: "activerecord8.0"
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Changed
+- ActiveRecord 8.0 is now included in the PostgreSQL/MySQL CI matrix on Ruby 3.2.
+- ActiveRecord dependency bounds now allow the full 8.0 patch line while excluding 8.1 until it is tested.
+
 ### Fixed
 - Reusing a builder after changing the selected result shape now returns Struct rows with the correct members instead of reusing a stale Struct class.
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ gem install simple_query
 SimpleQuery currently declares support for:
 
 - Ruby `>= 2.7`
-- ActiveRecord `>= 7.0`, `<= 8.0`
+- ActiveRecord `>= 7.0`, `< 8.1`
 
-The CI matrix covers ActiveRecord 7.0, 7.1, and 7.2 across PostgreSQL and MySQL. The gemspec currently allows ActiveRecord 8.0.0, but ActiveRecord 8 is not part of the CI matrix yet.
+The CI matrix covers ActiveRecord 7.0, 7.1, 7.2, and 8.0 across PostgreSQL and MySQL. ActiveRecord 8.0 is tested on Ruby 3.2 because Rails 8 requires Ruby 3.2 or newer.
 
 ## Configuration
 

--- a/simple_query.gemspec
+++ b/simple_query.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["lib/**/*", "LICENSE.txt", "README.md"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 7.0", "<= 8.0"
+  spec.add_dependency "activerecord", ">= 7.0", "< 8.1"
 end


### PR DESCRIPTION
## Summary
- Add ActiveRecord 8.0 to the PostgreSQL and MySQL CI matrices on Ruby 3.2.
- Allow the full ActiveRecord 8.0 patch line while continuing to exclude ActiveRecord 8.1 until it is tested.
- Update the README compatibility note and changelog for the expanded support matrix.

## Test Plan
- `ruby -Ilib -Ispec -e 'gem "activerecord", "= 8.0.5"; gem "sqlite3"; load Gem.bin_path("rspec-core", "rspec")' -- spec --format progress`
- `rubocop`
- `gem build simple_query.gemspec`
- `git diff --check`