### PR TITLE
fix: harden streaming failure handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,12 @@ Adapter behavior:
 - MySQL: uses `mysql2` streaming with `stream: true`, `cache_rows: false`, and `as: :hash`; `batch_size` is accepted by the public API but does not control MySQL batching
 - Other adapters: `stream_each` raises an error
 
+Failure behavior:
+
+- `batch_size` must be a positive integer; invalid values raise `ArgumentError` before any adapter-specific SQL runs
+- PostgreSQL streaming wraps the cursor in a transaction and rolls back if declaring, fetching, or row processing fails
+- MySQL streaming uses the mysql2 driver's streaming result handling; query and row processing errors are propagated to the caller
+
 ## Bulk updates
 
 `bulk_update` builds and executes a set-based `UPDATE` for the current query conditions:

--- a/lib/simple_query/builder.rb
+++ b/lib/simple_query/builder.rb
@@ -204,6 +204,8 @@ module SimpleQuery
     end
 
     def stream_each(batch_size: 1000, &block)
+      validate_stream_batch_size!(batch_size)
+
       adapter = ActiveRecord::Base.connection.adapter_name.downcase
       if adapter.include?("postgres")
         stream_each_postgres(batch_size, &block)
@@ -255,6 +257,12 @@ module SimpleQuery
     end
 
     private
+
+    def validate_stream_batch_size!(batch_size)
+      return if batch_size.is_a?(Integer) && batch_size.positive?
+
+      raise ArgumentError, "stream_each batch_size must be a positive Integer"
+    end
 
     def build_select_expressions
       expressions = []

--- a/lib/simple_query/stream/postgres_stream.rb
+++ b/lib/simple_query/stream/postgres_stream.rb
@@ -5,6 +5,8 @@ module SimpleQuery
     module PostgresStream
       # rubocop:disable Metrics/MethodLength
       def stream_each_postgres(batch_size, &block)
+        validate_postgres_stream_batch_size!(batch_size)
+
         select_sql = cached_sql
 
         conn = ActiveRecord::Base.connection.raw_connection
@@ -39,6 +41,12 @@ module SimpleQuery
       # rubocop:enable Metrics/MethodLength
 
       private
+
+      def validate_postgres_stream_batch_size!(batch_size)
+        return if batch_size.is_a?(Integer) && batch_size.positive?
+
+        raise ArgumentError, "stream_each batch_size must be a positive Integer"
+      end
 
       def build_row_object(pg_row)
         if @read_model_class

--- a/spec/simple_query/builder_spec.rb
+++ b/spec/simple_query/builder_spec.rb
@@ -604,6 +604,24 @@ RSpec.describe SimpleQuery::Builder do
         expect(builder).to receive(:stream_each_postgres).with(500).and_return(nil)
         builder.stream_each(batch_size: 500) { |row| }
       end
+
+      it "rejects invalid batch sizes before executing adapter-specific SQL" do
+        builder = described_class.new(User)
+
+        expect(builder).not_to receive(:stream_each_postgres)
+        expect do
+          builder.stream_each(batch_size: "1; DROP TABLE users") { |_row| }
+        end.to raise_error(ArgumentError, "stream_each batch_size must be a positive Integer")
+      end
+
+      it "rejects non-positive batch sizes" do
+        builder = described_class.new(User)
+
+        expect(builder).not_to receive(:stream_each_postgres)
+        expect do
+          builder.stream_each(batch_size: 0) { |_row| }
+        end.to raise_error(ArgumentError, "stream_each batch_size must be a positive Integer")
+      end
     end
 
     context "when adapter is mysql" do

--- a/spec/simple_query/stream/mysql_stream_spec.rb
+++ b/spec/simple_query/stream/mysql_stream_spec.rb
@@ -42,5 +42,17 @@ RSpec.describe SimpleQuery::Stream::MysqlStream do
 
       expect(rows).to eq([{ "mocked_mysql" => { "id" => 1 } }, { "mocked_mysql" => { "id" => 2 } }])
     end
+
+    it "propagates row processing errors" do
+      allow(ActiveRecord::Base).to receive_message_chain(:connection, :raw_connection).and_return(conn)
+      expect(conn).to receive(:query).with("SELECT * FROM users", stream: true, cache_rows: false, as: :hash)
+                                     .and_return(mysql_result)
+
+      allow(mysql_result).to receive(:each).and_yield({ "id" => 1 })
+
+      expect do
+        builder.stream_each_mysql { |_record| raise "consumer failed" }
+      end.to raise_error("consumer failed")
+    end
   end
 end

--- a/spec/simple_query/stream/postgres_stream_spec.rb
+++ b/spec/simple_query/stream/postgres_stream_spec.rb
@@ -54,7 +54,15 @@ RSpec.describe SimpleQuery::Stream::PostgresStream do
       expect(rows).to eq([{ "mocked" => "row1" }, { "mocked" => "row2" }])
     end
 
-    it "rolls back if an error occurs" do
+    it "rejects invalid direct PostgreSQL batch sizes before opening a cursor" do
+      expect(ActiveRecord::Base).not_to receive(:connection)
+
+      expect do
+        builder.stream_each_postgres("100") { |_record| }
+      end.to raise_error(ArgumentError, "stream_each batch_size must be a positive Integer")
+    end
+
+    it "rolls back if declaring the cursor fails" do
       expect(conn).to receive(:exec).with("BEGIN").ordered
       expect(conn).to receive(:exec).with(/DECLARE simple_query_cursor_\d+ NO SCROLL CURSOR FOR SELECT \* FROM users/)
                                     .ordered.and_raise("Boom!")
@@ -63,8 +71,48 @@ RSpec.describe SimpleQuery::Stream::PostgresStream do
       allow(ActiveRecord::Base).to receive_message_chain(:connection, :raw_connection).and_return(conn)
 
       expect do
-        builder.stream_each_postgres(100) { |r| }
+        builder.stream_each_postgres(100) { |_record| }
       end.to raise_error("Boom!")
+    end
+
+    it "rolls back if fetching from the cursor fails" do
+      expect(conn).to receive(:exec).with("BEGIN").ordered
+      expect(conn).to receive(:exec)
+        .with("DECLARE simple_query_cursor_#{builder.object_id} NO SCROLL CURSOR FOR SELECT * FROM users")
+        .ordered
+      expect(conn).to receive(:exec).with("FETCH 100 FROM simple_query_cursor_#{builder.object_id}")
+                                    .and_raise("fetch failed")
+      expect(conn).not_to receive(:exec).with("CLOSE simple_query_cursor_#{builder.object_id}")
+      expect(conn).not_to receive(:exec).with("COMMIT")
+      expect(conn).to receive(:exec).with("ROLLBACK")
+
+      allow(ActiveRecord::Base).to receive_message_chain(:connection, :raw_connection).and_return(conn)
+
+      expect do
+        builder.stream_each_postgres(100) { |_record| }
+      end.to raise_error("fetch failed")
+    end
+
+    it "rolls back and preserves the original error if row processing fails" do
+      expect(conn).to receive(:exec).with("BEGIN").ordered
+      expect(conn).to receive(:exec)
+        .with("DECLARE simple_query_cursor_#{builder.object_id} NO SCROLL CURSOR FOR SELECT * FROM users")
+        .ordered
+
+      fetch_result = double("PGResult", ntuples: 1)
+      allow(fetch_result).to receive(:each).and_yield("row1")
+
+      expect(conn).to receive(:exec).with("FETCH 100 FROM simple_query_cursor_#{builder.object_id}")
+                                    .and_return(fetch_result)
+      expect(conn).not_to receive(:exec).with("CLOSE simple_query_cursor_#{builder.object_id}")
+      expect(conn).not_to receive(:exec).with("COMMIT")
+      expect(conn).to receive(:exec).with("ROLLBACK")
+
+      allow(ActiveRecord::Base).to receive_message_chain(:connection, :raw_connection).and_return(conn)
+
+      expect do
+        builder.stream_each_postgres(100) { |_record| raise "consumer failed" }
+      end.to raise_error("consumer failed")
     end
   end
 end


### PR DESCRIPTION
## Summary
Hardens streaming failure handling by rejecting invalid PostgreSQL cursor batch sizes before they can be interpolated into streaming SQL. The change also documents how streaming behaves when PostgreSQL cursor setup, fetching, or row processing fails and how MySQL streaming propagates consumer errors.

## Changes
- Validate `stream_each` batch sizes as positive integers before adapter dispatch.
- Add defensive PostgreSQL streaming validation for direct internal path calls.
- Add regression specs for invalid batch sizes, PostgreSQL rollback paths, and MySQL row-processing errors.
- Document streaming failure behavior in the README.

## Test plan
- `git diff --check master..HEAD`
- GitHub Actions SimpleQuery CI matrix passed for PostgreSQL and MySQL across supported Ruby/ActiveRecord combinations.
- Claude Code review of the focused diff found no blocking findings.
