### PR TITLE
fix: improve simple_scope argument diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project are documented in this file.
 
 ## Unreleased
 
+### Breaking
+- `simple_scope` now validates positional argument counts before invoking scope bodies. Calls that previously relied on Ruby's lenient `Proc` argument handling now raise a named `ArgumentError` when too few or too many positional arguments are provided.
+
 ### Changed
 - ActiveRecord 8.0 is now included in the PostgreSQL/MySQL CI matrix on Ruby 3.2.
 - ActiveRecord dependency bounds now allow the full 8.0 patch line while excluding 8.1 until it is tested.
+- `simple_scope` now rejects invalid scope bodies at definition time.
 
 ### Fixed
 - Reusing a builder after changing the selected result shape now returns Struct rows with the correct members instead of reusing a stale Struct class.

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ User.simple_query
     .execute
 ```
 
-SimpleQuery validates positional scope arguments before invoking the scope body. If a scope is called with too few or too many positional arguments, it raises `ArgumentError` with the scope name and expected argument count.
+SimpleQuery validates positional scope arguments before invoking the scope body. If a scope is called with too few or too many positional arguments, it raises `ArgumentError` with the scope name and expected argument count. For scopes that declare Ruby keyword parameters, SimpleQuery forwards keywords to the scope body and lets Ruby raise its native keyword-argument errors.
 
 ## Lazy execution and streaming
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ User.simple_query
     .execute
 ```
 
+SimpleQuery validates positional scope arguments before invoking the scope body. If a scope is called with too few or too many positional arguments, it raises `ArgumentError` with the scope name and expected argument count.
+
 ## Lazy execution and streaming
 
 `lazy_execute` returns an `Enumerator` over the query results:

--- a/lib/simple_query.rb
+++ b/lib/simple_query.rb
@@ -46,12 +46,13 @@ module SimpleQuery
     end
 
     def simple_scope(name, body = nil, &block)
-      raise ArgumentError, "Pass either a proc/lambda or a block, not both" if body && block_given?
+      raise ArgumentError, "Pass either a proc/lambda or a block, not both" if !body.nil? && block_given?
 
-      scope_body = body || block
-      raise ArgumentError, "You must provide a block or a proc" unless scope_body
+      scope_body = body.nil? ? block : body
+      raise ArgumentError, "You must provide a block or a proc" if scope_body.nil?
+      raise ArgumentError, "simple_scope body must respond to #to_proc" unless scope_body.respond_to?(:to_proc)
 
-      _simple_scopes[name.to_sym] = scope_body
+      _simple_scopes[name.to_sym] = scope_body.to_proc
     end
   end
 

--- a/lib/simple_query.rb
+++ b/lib/simple_query.rb
@@ -52,7 +52,10 @@ module SimpleQuery
       raise ArgumentError, "You must provide a block or a proc" if scope_body.nil?
       raise ArgumentError, "simple_scope body must respond to #to_proc" unless scope_body.respond_to?(:to_proc)
 
-      _simple_scopes[name.to_sym] = scope_body.to_proc
+      scope_proc = scope_body.to_proc
+      raise ArgumentError, "simple_scope body #to_proc must return a Proc" unless scope_proc.is_a?(Proc)
+
+      _simple_scopes[name.to_sym] = scope_proc
     end
   end
 

--- a/lib/simple_query/builder.rb
+++ b/lib/simple_query/builder.rb
@@ -401,10 +401,10 @@ module SimpleQuery
       end
     end
 
-    def method_missing(method_name, *args, &block)
+    def method_missing(method_name, *args, **kwargs, &block)
       if (scope_block = find_scope(method_name))
-        validate_scope_arity!(method_name, scope_block, args)
-        instance_exec(*args, &scope_block)
+        validate_scope_arity!(method_name, scope_block, scope_arguments_for_validation(scope_block, args, kwargs))
+        instance_exec(*args, **kwargs, &scope_block)
         self
       else
         super
@@ -428,6 +428,12 @@ module SimpleQuery
 
       raise ArgumentError,
             "simple_scope :#{scope_name} expected #{scope_arity_description(range)}, provided #{provided}"
+    end
+
+    def scope_arguments_for_validation(scope_block, args, kwargs)
+      return args if kwargs.empty? || scope_uses_keyword_arguments?(scope_block)
+
+      args + [kwargs]
     end
 
     def scope_argument_range(scope_block)

--- a/lib/simple_query/builder.rb
+++ b/lib/simple_query/builder.rb
@@ -403,6 +403,7 @@ module SimpleQuery
 
     def method_missing(method_name, *args, &block)
       if (scope_block = find_scope(method_name))
+        validate_scope_arity!(method_name, scope_block, args)
         instance_exec(*args, &scope_block)
         self
       else
@@ -418,6 +419,64 @@ module SimpleQuery
       return unless model.respond_to?(:_simple_scopes)
 
       model._simple_scopes[method_name.to_sym]
+    end
+
+    def validate_scope_arity!(scope_name, scope_block, args)
+      range = scope_argument_range(scope_block)
+      provided = args.length
+      return if scope_arity_matches?(range, provided)
+
+      raise ArgumentError,
+            "simple_scope :#{scope_name} expected #{scope_arity_description(range)}, provided #{provided}"
+    end
+
+    def scope_argument_range(scope_block)
+      # Keyword argument arity has Ruby-version-specific edge cases; let Ruby raise its native error.
+      return nil if scope_uses_keyword_arguments?(scope_block)
+
+      minimum = minimum_scope_arguments(scope_block)
+      maximum = maximum_scope_arguments(scope_block)
+
+      [minimum, maximum]
+    end
+
+    def scope_uses_keyword_arguments?(scope_block)
+      scope_block.parameters.any? { |kind, _name| [:key, :keyreq, :keyrest].include?(kind) }
+    end
+
+    def minimum_scope_arguments(scope_block)
+      arity = scope_block.arity
+      return arity if arity >= 0
+
+      -arity - 1
+    end
+
+    def maximum_scope_arguments(scope_block)
+      parameters = scope_block.parameters
+      return nil if parameters.any? { |kind, _name| kind == :rest }
+
+      parameters.count { |kind, _name| [:req, :opt].include?(kind) }
+    end
+
+    def scope_arity_matches?(range, provided)
+      return true if range.nil?
+
+      minimum, maximum = range
+      return provided >= minimum if maximum.nil?
+
+      provided.between?(minimum, maximum)
+    end
+
+    def scope_arity_description(range)
+      minimum, maximum = range
+      return "at least #{argument_count_description(minimum)}" if maximum.nil?
+      return "exactly #{argument_count_description(minimum)}" if minimum == maximum
+
+      "#{minimum} to #{argument_count_description(maximum)}"
+    end
+
+    def argument_count_description(count)
+      "#{count} #{count == 1 ? "argument" : "arguments"}"
     end
   end
 end

--- a/spec/simple_query/builder_spec.rb
+++ b/spec/simple_query/builder_spec.rb
@@ -535,6 +535,22 @@ RSpec.describe SimpleQuery::Builder do
       end.to raise_error(ArgumentError, "simple_scope body must respond to #to_proc")
     end
 
+    it "rejects scope bodies whose to_proc does not return a Proc" do
+      invalid_body = Class.new do
+        def to_proc
+          :not_a_proc
+        end
+      end.new
+
+      model = Class.new do
+        include SimpleQuery
+      end
+
+      expect do
+        model.simple_scope(:invalid, invalid_body)
+      end.to raise_error(ArgumentError, "simple_scope body #to_proc must return a Proc")
+    end
+
     it "reports existing and missing scopes through standard method lookup" do
       builder = User.simple_query
 
@@ -613,6 +629,42 @@ RSpec.describe SimpleQuery::Builder do
     it "handles parameterized scope" do
       results = User.simple_query.by_name("John Smith").execute
       expect(results.map(&:name)).to eq(["John Smith"])
+    end
+
+    it "forwards keyword arguments to scope bodies" do
+      User.simple_scope(:by_status_and_admin) do |status:, admin: false|
+        where(status: status, admin: admin)
+      end
+
+      results = User.simple_query.by_status_and_admin(status: 1, admin: true).execute
+
+      expect(results.map(&:name)).to eq(["Jane Doe"])
+    ensure
+      User._simple_scopes.delete(:by_status_and_admin)
+    end
+
+    it "preserves keyword-style calls to positional hash scopes" do
+      User.simple_scope(:by_filters) do |filters|
+        where(filters)
+      end
+
+      results = User.simple_query.by_filters(status: 1, admin: true).execute
+
+      expect(results.map(&:name)).to eq(["Jane Doe"])
+    ensure
+      User._simple_scopes.delete(:by_filters)
+    end
+
+    it "counts keyword-style hashes with positional arguments for positional-only scopes" do
+      User.simple_scope(:by_name_and_filters) do |name, filters|
+        where(filters).where(name: name)
+      end
+
+      results = User.simple_query.by_name_and_filters("Jane Doe", status: 1, admin: true).execute
+
+      expect(results.map(&:name)).to eq(["Jane Doe"])
+    ensure
+      User._simple_scopes.delete(:by_name_and_filters)
     end
 
     it "chains multiple scopes" do

--- a/spec/simple_query/builder_spec.rb
+++ b/spec/simple_query/builder_spec.rb
@@ -525,33 +525,102 @@ RSpec.describe SimpleQuery::Builder do
   end
 
   describe "Scopes" do
+    it "rejects non-callable simple_scope bodies at definition time" do
+      model = Class.new do
+        include SimpleQuery
+      end
+
+      expect do
+        model.simple_scope(:invalid, Object.new)
+      end.to raise_error(ArgumentError, "simple_scope body must respond to #to_proc")
+    end
+
+    it "reports existing and missing scopes through standard method lookup" do
+      builder = User.simple_query
+
+      expect(builder).to respond_to(:active)
+      expect(builder).not_to respond_to(:missing_scope)
+      expect do
+        builder.missing_scope
+      end.to raise_error(NoMethodError, /missing_scope/)
+    end
+
+    it "raises a diagnostic ArgumentError when scope arguments have the wrong arity" do
+      expect do
+        User.simple_query.by_name
+      end.to raise_error(ArgumentError, /simple_scope :by_name expected exactly 1 argument, provided 0/)
+    end
+
+    it "allows optional scope arguments" do
+      User.simple_scope(:optional_status) { |status = 1| where(status: status) }
+
+      expect(User.simple_query.optional_status.execute.map(&:name)).to contain_exactly("Jane Doe", "John Smith")
+      expect(User.simple_query.optional_status(999).execute).to be_empty
+    ensure
+      User._simple_scopes.delete(:optional_status)
+    end
+
+    it "raises a diagnostic ArgumentError when too many optional scope arguments are provided" do
+      User.simple_scope(:optional_status) { |status = 1| where(status: status) }
+
+      expect do
+        User.simple_query.optional_status(1, 2)
+      end.to raise_error(ArgumentError, /simple_scope :optional_status expected 0 to 1 argument, provided 2/)
+    ensure
+      User._simple_scopes.delete(:optional_status)
+    end
+
+    it "allows rest arguments in scopes" do
+      User.simple_scope(:select_fields) do |*fields|
+        select(*fields)
+      end
+
+      result = User.simple_query.select_fields(:name, :email).where(name: "Jane Doe").execute.first
+
+      expect(result.members).to eq([:name, :email])
+    ensure
+      User._simple_scopes.delete(:select_fields)
+    end
+
+    it "returns the builder when a scope body returns nil" do
+      User.simple_scope(:returns_nil) { nil }
+      builder = User.simple_query
+
+      expect(builder.returns_nil).to equal(builder)
+    ensure
+      User._simple_scopes.delete(:returns_nil)
+    end
+
+    it "returns the builder when a scope body returns another value" do
+      User.simple_scope(:returns_value) { "ignored" }
+      builder = User.simple_query
+
+      expect(builder.returns_value).to equal(builder)
+    ensure
+      User._simple_scopes.delete(:returns_value)
+    end
+
     it "filters records by a parameterless scope (active)" do
-      # The 'Inactive Guy' should not appear in results
       results = User.simple_query.active.execute
       expect(results.map(&:name)).to contain_exactly("Jane Doe", "John Smith")
     end
 
     it "filters records by another parameterless scope (admins)" do
-      # Only Jane Doe is admin => see above seed data
       results = User.simple_query.admins.execute
       expect(results.map(&:name)).to eq(["Jane Doe"])
     end
 
     it "handles parameterized scope" do
-      # We search by name using the by_name scope
       results = User.simple_query.by_name("John Smith").execute
       expect(results.map(&:name)).to eq(["John Smith"])
     end
 
     it "chains multiple scopes" do
-      # 'Jane Doe' is both active and an admin
-      # 'John Smith' is active but not an admin
       results = User.simple_query.active.admins.execute
       expect(results.map(&:name)).to eq(["Jane Doe"])
     end
 
     it "chains scopes with additional DSL methods" do
-      # Filter by :by_name, then check if it's active, and then select
       results = User.simple_query
                     .by_name("Jane Doe")
                     .active


### PR DESCRIPTION
## Summary
Improves `simple_scope` diagnostics so invalid scope bodies are rejected when defined and positional argument mismatches raise a named `ArgumentError` before the scope body runs. The argument validation intentionally tightens previously lenient Proc/block behavior, so calls with too few or too many positional scope arguments now fail clearly instead of relying on Ruby's implicit nil/drop semantics.

## Changes
- Validate scope bodies with `to_proc` during `simple_scope` definition and store the normalized proc.
- Add named positional arity validation for exact, optional, and rest-argument scopes.
- Preserve Ruby-native handling for keyword-argument scopes.
- Document the behavior in the README and CHANGELOG, including the breaking validation change.
- Add RSpec coverage for invalid bodies, scope lookup, arity diagnostics, optional/rest arguments, and builder return behavior.

## Test plan
- RSpec suite passed.
- RuboCop passed for the touched Ruby files.
- Diff whitespace check passed.
