### PR TITLE
chore: add reproducible benchmark harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,29 @@ User.simple_query
 
 SimpleQuery is designed for read paths where ActiveRecord model instantiation is unnecessary overhead. Returning structs or read models can reduce allocation costs for large reporting-style queries.
 
-The repository includes performance specs and benchmark-oriented tests comparing ActiveRecord object loading with SimpleQuery result objects and streaming. Treat benchmark numbers as workload-specific: validate them against your database, indexes, adapter, and query shape before making production claims.
+The repository includes an optional benchmark harness comparing ActiveRecord object loading and `update_all` with SimpleQuery structs, read models, and `bulk_update`. Treat benchmark numbers as workload-specific: validate them against your database, indexes, adapter, Ruby version, and query shape before making production claims.
+
+Run the reproducible local benchmark with:
+
+```sh
+bundle exec rake benchmark:reproducible
+```
+
+The harness uses SQLite by default, seeds deterministic data, warms up and repeats each timing measurement, and prints JSON with environment metadata plus timing results. If `memory_profiler` is available in your development bundle, the JSON also includes single-run allocation profiles for the read-path scenarios. Tune the workload with environment variables:
+
+```sh
+BENCHMARK_ROWS=50000 BENCHMARK_WARMUP=3 BENCHMARK_RUNS=10 \
+  bundle exec rake benchmark:reproducible
+```
+
+Available variables:
+
+- `BENCHMARK_ROWS` (default: `10000`) controls the number of users and matching companies seeded.
+- `BENCHMARK_WARMUP` (default: `2`) controls warmup iterations before samples are collected.
+- `BENCHMARK_RUNS` (default: `5`) controls the number of timed samples per scenario.
+- `BENCHMARK_DATABASE` (default: `:memory:`) can point at a SQLite database file if you want to inspect the generated benchmark-specific tables. The harness drops and recreates `simple_query_benchmark_users` and `simple_query_benchmark_companies` in that database on every run.
+
+Use captured benchmark output only as a reproducibility artifact. Do not compare runs from different hardware, databases, Ruby versions, or dependency sets as if they were equivalent.
 
 ## Safety notes
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,8 @@ RuboCop::RakeTask.new
 namespace :benchmark do
   desc "Run the optional reproducible SimpleQuery benchmark harness"
   task :reproducible do
-    $LOAD_PATH.unshift File.expand_path("lib", __dir__)
+    lib_path = File.expand_path("lib", __dir__)
+    $LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
     require_relative "benchmark/simple_query_benchmark"
     SimpleQueryBenchmark.run
   end

--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,13 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
+namespace :benchmark do
+  desc "Run the optional reproducible SimpleQuery benchmark harness"
+  task :reproducible do
+    $LOAD_PATH.unshift File.expand_path("lib", __dir__)
+    require_relative "benchmark/simple_query_benchmark"
+    SimpleQueryBenchmark.run
+  end
+end
+
 task default: [:spec, :rubocop]

--- a/benchmark/simple_query_benchmark.rb
+++ b/benchmark/simple_query_benchmark.rb
@@ -47,12 +47,15 @@ module SimpleQueryBenchmark # rubocop:disable Metrics/ModuleLength
   end
 
   def integer_env(name, default)
-    value = Integer(ENV.fetch(name, default).to_s, 10)
+    value = begin
+      Integer(ENV.fetch(name, default).to_s, 10)
+    rescue ArgumentError
+      raise ArgumentError, "#{name} must be a positive integer"
+    end
+
     raise ArgumentError, "#{name} must be positive" unless value.positive?
 
     value
-  rescue ArgumentError
-    raise ArgumentError, "#{name} must be a positive integer"
   end
 
   def setup_database(config)
@@ -206,12 +209,15 @@ module SimpleQueryBenchmark # rubocop:disable Metrics/ModuleLength
   end
 
   def memory_results
-    return "memory_profiler unavailable" unless defined?(MemoryProfiler)
+    return { available: false, reason: "memory_profiler unavailable" } unless defined?(MemoryProfiler)
 
     {
-      active_record_objects: memory_profile { active_record_objects },
-      simple_query_structs: memory_profile { simple_query_structs },
-      simple_query_read_models: memory_profile { simple_query_read_models }
+      available: true,
+      profiles: {
+        active_record_objects: memory_profile { active_record_objects },
+        simple_query_structs: memory_profile { simple_query_structs },
+        simple_query_read_models: memory_profile { simple_query_read_models }
+      }
     }
   end
 

--- a/benchmark/simple_query_benchmark.rb
+++ b/benchmark/simple_query_benchmark.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require "active_record"
+require "benchmark"
+require "json"
+require "simple_query"
+require "simple_query/version"
+
+begin
+  require "memory_profiler"
+rescue LoadError
+  nil
+end
+
+module SimpleQueryBenchmark # rubocop:disable Metrics/ModuleLength
+  DEFAULT_ROWS = 10_000
+  DEFAULT_RUNS = 5
+  DEFAULT_WARMUP = 2
+  USERS_TABLE = :simple_query_benchmark_users
+  COMPANIES_TABLE = :simple_query_benchmark_companies
+  STATUSES = [0, 1, 2].freeze
+  INDUSTRIES = ["Technology", "Finance", "Healthcare", "Education"].freeze
+
+  module_function
+
+  def run
+    config = benchmark_config
+    setup_database(config)
+    seed_data(config.fetch(:rows))
+
+    results = {
+      metadata: metadata(config),
+      timings: timing_results(config),
+      memory: memory_results
+    }
+
+    puts JSON.pretty_generate(results)
+  end
+
+  def benchmark_config
+    {
+      rows: integer_env("BENCHMARK_ROWS", DEFAULT_ROWS),
+      runs: integer_env("BENCHMARK_RUNS", DEFAULT_RUNS),
+      warmup: integer_env("BENCHMARK_WARMUP", DEFAULT_WARMUP),
+      database: ENV.fetch("BENCHMARK_DATABASE", ":memory:")
+    }
+  end
+
+  def integer_env(name, default)
+    value = Integer(ENV.fetch(name, default).to_s, 10)
+    raise ArgumentError, "#{name} must be positive" unless value.positive?
+
+    value
+  rescue ArgumentError
+    raise ArgumentError, "#{name} must be a positive integer"
+  end
+
+  def setup_database(config)
+    ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: config.fetch(:database))
+    ActiveRecord::Migration.verbose = false
+
+    ActiveRecord::Schema.define do
+      drop_table COMPANIES_TABLE, if_exists: true
+      drop_table USERS_TABLE, if_exists: true
+
+      create_table USERS_TABLE do |t|
+        t.string :name
+        t.string :email
+        t.boolean :active
+        t.integer :status
+      end
+
+      create_table COMPANIES_TABLE do |t|
+        t.string :name
+        t.integer :user_id
+        t.string :industry
+        t.boolean :active
+        t.integer :status
+      end
+    end
+
+    ActiveRecord::Base.include(SimpleQuery)
+  end
+
+  def seed_data(rows)
+    users = Array.new(rows) do |index|
+      {
+        name: "User #{index}",
+        email: "user-#{index}@example.test",
+        active: index.even?,
+        status: STATUSES[index % STATUSES.length]
+      }
+    end
+
+    User.insert_all!(users)
+
+    user_ids = User.order(:id).pluck(:id)
+    companies = user_ids.each_with_index.map do |user_id, index|
+      {
+        name: "Company #{index}",
+        user_id: user_id,
+        industry: INDUSTRIES[index % INDUSTRIES.length],
+        active: index.even?,
+        status: STATUSES[index % STATUSES.length]
+      }
+    end
+
+    Company.insert_all!(companies)
+  end
+
+  def metadata(config)
+    {
+      ruby: RUBY_DESCRIPTION,
+      active_record: ActiveRecord::VERSION::STRING,
+      simple_query: SimpleQuery::VERSION,
+      adapter: ActiveRecord::Base.connection.adapter_name,
+      rows: config.fetch(:rows),
+      runs: config.fetch(:runs),
+      warmup: config.fetch(:warmup),
+      database: config.fetch(:database)
+    }
+  end
+
+  def timing_results(config)
+    {
+      active_record_objects: measure(config) { active_record_objects },
+      simple_query_structs: measure(config) { simple_query_structs },
+      simple_query_read_models: measure(config) { simple_query_read_models },
+      active_record_update_all: measure_update(config) { active_record_update_all },
+      simple_query_bulk_update: measure_update(config) { simple_query_bulk_update }
+    }
+  end
+
+  def measure(config, &block)
+    config.fetch(:warmup).times(&block)
+
+    samples = Array.new(config.fetch(:runs)) do
+      Benchmark.realtime(&block)
+    end
+
+    summarize_samples(samples)
+  end
+
+  def measure_update(config, &block)
+    config.fetch(:warmup).times do
+      reset_update_rows
+      block.call
+    end
+
+    samples = Array.new(config.fetch(:runs)) do
+      reset_update_rows
+      Benchmark.realtime(&block)
+    end
+
+    summarize_samples(samples)
+  end
+
+  def summarize_samples(samples)
+    {
+      samples_seconds: samples.map { |sample| sample.round(6) },
+      min_seconds: samples.min.round(6),
+      average_seconds: (samples.sum / samples.length).round(6)
+    }
+  end
+
+  def active_record_objects
+    ActiveRecord::Base.uncached do
+      User.joins(:company)
+          .where(User.table_name => { active: true })
+          .select("#{User.table_name}.id", "#{User.table_name}.name")
+          .to_a
+    end
+  end
+
+  def simple_query_structs
+    ActiveRecord::Base.uncached do
+      User.simple_query
+          .select(:id, :name)
+          .join(USERS_TABLE, COMPANIES_TABLE, foreign_key: :user_id, primary_key: :id)
+          .where(active: true)
+          .execute
+    end
+  end
+
+  def simple_query_read_models
+    ActiveRecord::Base.uncached do
+      User.simple_query
+          .select(:id, :name)
+          .join(USERS_TABLE, COMPANIES_TABLE, foreign_key: :user_id, primary_key: :id)
+          .where(active: true)
+          .map_to(UserReadModel)
+          .execute
+    end
+  end
+
+  def active_record_update_all
+    User.where(active: false).update_all(status: 1)
+  end
+
+  def simple_query_bulk_update
+    User.simple_query.where(active: false).bulk_update(set: { status: 1 })
+  end
+
+  def reset_update_rows
+    User.where(active: false).update_all(status: 0)
+  end
+
+  def memory_results
+    return "memory_profiler unavailable" unless defined?(MemoryProfiler)
+
+    {
+      active_record_objects: memory_profile { active_record_objects },
+      simple_query_structs: memory_profile { simple_query_structs },
+      simple_query_read_models: memory_profile { simple_query_read_models }
+    }
+  end
+
+  def memory_profile(&block)
+    report = MemoryProfiler.report(&block)
+
+    {
+      total_allocated: report.total_allocated,
+      total_allocated_memsize: report.total_allocated_memsize
+    }
+  end
+
+  class User < ActiveRecord::Base
+    self.table_name = USERS_TABLE.to_s
+    has_one :company, class_name: "SimpleQueryBenchmark::Company"
+  end
+
+  class Company < ActiveRecord::Base
+    self.table_name = COMPANIES_TABLE.to_s
+    belongs_to :user, class_name: "SimpleQueryBenchmark::User"
+  end
+
+  class UserReadModel < SimpleQuery::ReadModel
+    attribute :id
+    attribute :name
+  end
+end
+
+SimpleQueryBenchmark.run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
## Summary
Adds a reproducible benchmark harness for validating SimpleQuery performance claims against a deterministic local SQLite workload. The harness records environment metadata, repeated timing samples, and optional read-path allocation profiles so benchmark output can be compared responsibly within the same environment.

## Changes
- Adds `benchmark/simple_query_benchmark.rb` with deterministic seed data, read-path comparisons, update-path comparisons, strict benchmark configuration parsing, and JSON output.
- Adds `rake benchmark:reproducible` as the optional benchmark entry point.
- Documents how to run the harness, tune workload size and sample counts, and interpret benchmark output without overgeneralizing across environments.

## Test plan
- Ran the benchmark task with a reduced deterministic workload and validated the JSON output.
- Ran the full RSpec suite: 160 examples, 0 failures, 5 pending.
- Ran RuboCop: 40 files inspected, no offenses detected.
- Ran `git diff --check`.
