### PR TITLE
ci: align ActiveRecord support matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.7", "3.0", "3.1", "3.2"]
+        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
         ar-gemfile: ["activerecord7.0", "activerecord7.1", "activerecord7.2", "activerecord8.0"]
         exclude:
           # ActiveRecord 7.2 => requires Ruby >= 3.1
@@ -35,6 +35,12 @@ jobs:
             ar-gemfile: "activerecord7.2"
           - ruby-version: "3.0"
             ar-gemfile: "activerecord7.2"
+          # ActiveRecord 7.0 is covered through Ruby 3.2; newer Rubies are
+          # covered by the Rails versions that support them directly.
+          - ruby-version: "3.3"
+            ar-gemfile: "activerecord7.0"
+          - ruby-version: "3.4"
+            ar-gemfile: "activerecord7.0"
           # ActiveRecord 8.0 => requires Ruby >= 3.2
           - ruby-version: "2.7"
             ar-gemfile: "activerecord8.0"
@@ -103,13 +109,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.7", "3.0", "3.1", "3.2"]
+        ruby-version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
         ar-gemfile: ["activerecord7.0", "activerecord7.1", "activerecord7.2", "activerecord8.0"]
         exclude:
           - ruby-version: "2.7"
             ar-gemfile: "activerecord7.2"
           - ruby-version: "3.0"
             ar-gemfile: "activerecord7.2"
+          # ActiveRecord 7.0 is covered through Ruby 3.2; newer Rubies are
+          # covered by the Rails versions that support them directly.
+          - ruby-version: "3.3"
+            ar-gemfile: "activerecord7.0"
+          - ruby-version: "3.4"
+            ar-gemfile: "activerecord7.0"
           # ActiveRecord 8.0 => requires Ruby >= 3.2
           - ruby-version: "2.7"
             ar-gemfile: "activerecord8.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           - ruby-version: "3.0"
             ar-gemfile: "activerecord7.2"
           # ActiveRecord 7.0 is covered through Ruby 3.2; newer Rubies are
-          # covered by the Rails versions that support them directly.
+          # covered by the ActiveRecord versions that support them directly.
           - ruby-version: "3.3"
             ar-gemfile: "activerecord7.0"
           - ruby-version: "3.4"
@@ -117,7 +117,7 @@ jobs:
           - ruby-version: "3.0"
             ar-gemfile: "activerecord7.2"
           # ActiveRecord 7.0 is covered through Ruby 3.2; newer Rubies are
-          # covered by the Rails versions that support them directly.
+          # covered by the ActiveRecord versions that support them directly.
           - ruby-version: "3.3"
             ar-gemfile: "activerecord7.0"
           - ruby-version: "3.4"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ SimpleQuery currently declares support for:
 - Ruby `>= 2.7`
 - ActiveRecord `>= 7.0`, `< 8.1`
 
-The CI matrix covers ActiveRecord 7.0, 7.1, 7.2, and 8.0 across PostgreSQL and MySQL. ActiveRecord 7.0 is covered through Ruby 3.2; ActiveRecord 8.0 requires Ruby 3.2 or newer; otherwise each Ruby is exercised on the Rails versions that support it.
+The CI matrix covers ActiveRecord 7.0, 7.1, 7.2, and 8.0 across PostgreSQL and MySQL. ActiveRecord 7.0 is covered through Ruby 3.2; ActiveRecord 8.0 requires Ruby 3.2 or newer; otherwise each Ruby is exercised on the ActiveRecord versions that support it.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ SimpleQuery currently declares support for:
 - Ruby `>= 2.7`
 - ActiveRecord `>= 7.0`, `< 8.1`
 
-The CI matrix covers ActiveRecord 7.0, 7.1, 7.2, and 8.0 across PostgreSQL and MySQL. ActiveRecord 8.0 is tested on Ruby 3.2 because Rails 8 requires Ruby 3.2 or newer.
+The CI matrix covers ActiveRecord 7.0, 7.1, 7.2, and 8.0 across PostgreSQL and MySQL. ActiveRecord 7.0 is covered through Ruby 3.2; ActiveRecord 8.0 requires Ruby 3.2 or newer; otherwise each Ruby is exercised on the Rails versions that support it.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
Aligns the documented SimpleQuery support matrix with the GitHub Actions compatibility matrix. The CI matrix now covers current stable Rubies in addition to the existing Ruby and ActiveRecord combinations, while excluding combinations outside upstream Rails support windows.

## Changes
- Add Ruby 3.3 and 3.4 to the PostgreSQL and MySQL ActiveRecord CI matrices.
- Keep ActiveRecord 7.0 coverage bounded to Ruby versions it directly supports.
- Update README compatibility wording to describe the tested Ruby and ActiveRecord support window.

## Test Plan
- Parsed the GitHub Actions workflow YAML successfully.
- Verified the generated matrix combinations for PostgreSQL and MySQL.
- Checked the diff for whitespace errors.
