### PR TITLE
docs: clarify condition safety boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,17 +121,21 @@ User.simple_query
 
 ### Placeholder conditions
 
-Array conditions are sanitized through ActiveRecord's `sanitize_sql_array`, so they are the preferred way to use SQL fragments with user-provided values:
+Array conditions are sanitized through ActiveRecord's `sanitize_sql_array`, so they are the preferred way to use SQL fragments with external or user-provided values:
 
 ```ruby
+search_pattern = "%#{params[:search]}%"
+
 User.simple_query
-    .where(["name LIKE ?", "%Jane%"])
+    .where(["name LIKE ?", search_pattern])
     .execute
 
 User.simple_query
-    .where(["email = :email", { email: "jane@example.com" }])
+    .where(["email = :email", { email: params[:email] }])
     .execute
 ```
+
+Keep the SQL fragment itself static and pass dynamic values as positional or named placeholders. Do not interpolate request parameters, form values, or other untrusted input into the SQL string.
 
 ### Raw SQL conditions
 
@@ -143,7 +147,7 @@ User.simple_query
     .execute
 ```
 
-Only use raw SQL strings with trusted input. For external or user-provided values, prefer hash, Arel, or placeholder conditions.
+Raw SQL strings are an escape hatch for trusted, application-owned SQL only. If any value comes from a user, request, file, or external service, use hash, Arel, or placeholder conditions instead.
 
 ## Joins
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ User.simple_query
 Array conditions are sanitized through ActiveRecord's `sanitize_sql_array`, so they are the preferred way to use SQL fragments with external or user-provided values:
 
 ```ruby
-search_pattern = "%#{params[:search]}%"
+escaped_search = ActiveRecord::Base.sanitize_sql_like(params[:search].to_s)
+search_pattern = "%#{escaped_search}%"
 
 User.simple_query
     .where(["name LIKE ?", search_pattern])

--- a/spec/simple_query/builder_spec.rb
+++ b/spec/simple_query/builder_spec.rb
@@ -454,9 +454,11 @@ RSpec.describe SimpleQuery::Builder do
     it "sanitizes placeholder condition values instead of treating them as SQL" do
       expect(User.count).to be_positive
 
+      injection_sentinel = "__simple_query_placeholder_injection_sentinel_DO_NOT_CREATE__' OR 1=1 --"
+
       result = User.simple_query
                    .select(:name)
-                   .where(["name = ?", "Jane Doe' OR 1=1 --"])
+                   .where(["name = ?", injection_sentinel])
                    .execute
 
       expect(result).to be_empty

--- a/spec/simple_query/builder_spec.rb
+++ b/spec/simple_query/builder_spec.rb
@@ -450,6 +450,17 @@ RSpec.describe SimpleQuery::Builder do
 
       expect(result.size).to eq(1)
     end
+
+    it "sanitizes placeholder condition values instead of treating them as SQL" do
+      expect(User.count).to be_positive
+
+      result = User.simple_query
+                   .select(:name)
+                   .where(["name = ?", "Jane Doe' OR 1=1 --"])
+                   .execute
+
+      expect(result).to be_empty
+    end
   end
 
   describe "#lazy_execute" do


### PR DESCRIPTION
## Summary
Clarifies how SimpleQuery callers should separate trusted SQL fragments from dynamic values when using `where`. The README now shows placeholder-based patterns for external input and frames raw SQL strings as an application-owned escape hatch.

## Changes
- Update condition documentation to keep SQL fragments static and pass dynamic values through positional or named placeholders.
- Strengthen raw SQL wording so user, request, file, and external-service values are directed to hash, Arel, or placeholder conditions.
- Add regression coverage proving a SQL-injection-style placeholder value is treated as data, not executable SQL.

## Test plan
- Diff whitespace check passed.
- SimpleQuery CI passed across the PostgreSQL/MySQL Ruby and ActiveRecord matrix.
