### PR TITLE
fix: type unsupported streaming adapter errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 - Reusing a builder after changing the selected result shape now returns Struct rows with the correct members instead of reusing a stale Struct class.
+- Unsupported `stream_each` adapters now raise `SimpleQuery::UnsupportedAdapterError` with the adapter name instead of a generic runtime error.
 
 ## [0.5.0] - 2025-08-29
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ Adapter behavior:
 
 - PostgreSQL: uses a server-side cursor with `DECLARE` / `FETCH`; `batch_size` controls the number of rows fetched per cursor read
 - MySQL: uses `mysql2` streaming with `stream: true`, `cache_rows: false`, and `as: :hash`; `batch_size` is accepted by the public API but does not control MySQL batching
-- Other adapters: `stream_each` raises an error
+- Other adapters: `stream_each` raises `SimpleQuery::UnsupportedAdapterError` with the current adapter name
 
 Failure behavior:
 

--- a/lib/simple_query.rb
+++ b/lib/simple_query.rb
@@ -19,6 +19,8 @@ require_relative "simple_query/clauses/aggregation_clause"
 module SimpleQuery
   extend ActiveSupport::Concern
 
+  class UnsupportedAdapterError < StandardError; end
+
   class Configuration
     attr_accessor :auto_include_ar
 

--- a/lib/simple_query/builder.rb
+++ b/lib/simple_query/builder.rb
@@ -212,7 +212,7 @@ module SimpleQuery
       elsif adapter.include?("mysql")
         stream_each_mysql(&block)
       else
-        raise "stream_each is only implemented for Postgres and MySQL."
+        raise UnsupportedAdapterError, "stream_each is only implemented for PostgreSQL and MySQL adapters (current adapter: #{adapter})"
       end
     end
 

--- a/lib/simple_query/builder.rb
+++ b/lib/simple_query/builder.rb
@@ -206,14 +206,15 @@ module SimpleQuery
     def stream_each(batch_size: 1000, &block)
       validate_stream_batch_size!(batch_size)
 
-      adapter = ActiveRecord::Base.connection.adapter_name.downcase
+      adapter_name = ActiveRecord::Base.connection.adapter_name
+      adapter = adapter_name.downcase
       if adapter.include?("postgres")
         stream_each_postgres(batch_size, &block)
       elsif adapter.include?("mysql")
         stream_each_mysql(&block)
       else
         message = "stream_each is only implemented for PostgreSQL and MySQL adapters " \
-                  "(current adapter: #{adapter})"
+                  "(current adapter: #{adapter_name})"
         raise UnsupportedAdapterError, message
       end
     end

--- a/lib/simple_query/builder.rb
+++ b/lib/simple_query/builder.rb
@@ -212,7 +212,9 @@ module SimpleQuery
       elsif adapter.include?("mysql")
         stream_each_mysql(&block)
       else
-        raise UnsupportedAdapterError, "stream_each is only implemented for PostgreSQL and MySQL adapters (current adapter: #{adapter})"
+        message = "stream_each is only implemented for PostgreSQL and MySQL adapters " \
+                  "(current adapter: #{adapter})"
+        raise UnsupportedAdapterError, message
       end
     end
 

--- a/spec/simple_query/builder_spec.rb
+++ b/spec/simple_query/builder_spec.rb
@@ -841,7 +841,7 @@ RSpec.describe SimpleQuery::Builder do
         expect { builder.stream_each }
           .to raise_error(
             SimpleQuery::UnsupportedAdapterError,
-            "stream_each is only implemented for PostgreSQL and MySQL adapters (current adapter: sqlite)"
+            "stream_each is only implemented for PostgreSQL and MySQL adapters (current adapter: SQLite)"
           )
       end
     end

--- a/spec/simple_query/builder_spec.rb
+++ b/spec/simple_query/builder_spec.rb
@@ -834,11 +834,15 @@ RSpec.describe SimpleQuery::Builder do
     end
 
     context "when adapter is neither" do
-      it "raises an error" do
+      it "raises a typed unsupported adapter error with the adapter name" do
         builder = described_class.new(User)
-        allow(ActiveRecord::Base.connection).to receive(:adapter_name).and_return("Sqlite")
+        allow(ActiveRecord::Base.connection).to receive(:adapter_name).and_return("SQLite")
 
-        expect { builder.stream_each }.to raise_error("stream_each is only implemented for Postgres and MySQL.")
+        expect { builder.stream_each }
+          .to raise_error(
+            SimpleQuery::UnsupportedAdapterError,
+            "stream_each is only implemented for PostgreSQL and MySQL adapters (current adapter: sqlite)"
+          )
       end
     end
   end


### PR DESCRIPTION
## Summary
Unsupported adapters now fail with a typed streaming error instead of a generic runtime exception. This makes `stream_each` failures easier for callers to rescue and diagnose while preserving the existing PostgreSQL/MySQL streaming behavior.

## Changes
- Added `SimpleQuery::UnsupportedAdapterError`.
- Updated `stream_each` to include the unsupported adapter name in the error message.
- Added regression coverage for the SQLite/unsupported-adapter path.
- Updated streaming documentation and the changelog.

## Test plan
- Ruby syntax checks passed for the touched Ruby files.
- Static diff checks passed.