### PR TITLE
fix: clean up PostgreSQL stream cursors on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project are documented in this file.
 - `simple_scope` now rejects invalid scope bodies at definition time.
 
 ### Fixed
+- PostgreSQL `stream_each` now closes a declared cursor before rollback when row processing fails and attempts cursor cleanup before rollback on fetch failures.
 - Reusing a builder after changing the selected result shape now returns Struct rows with the correct members instead of reusing a stale Struct class.
 - Unsupported `stream_each` adapters now raise `SimpleQuery::UnsupportedAdapterError` with the adapter name instead of a generic runtime error.
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Adapter behavior:
 Failure behavior:
 
 - `batch_size` must be a positive integer; invalid values raise `ArgumentError` before any adapter-specific SQL runs
-- PostgreSQL streaming wraps the cursor in a transaction and rolls back if declaring, fetching, or row processing fails
+- PostgreSQL streaming wraps the cursor in a transaction, closes a declared cursor before rollback when row processing fails, attempts cursor cleanup before rollback on fetch failures, and propagates the original error
 - MySQL streaming uses the mysql2 driver's streaming result handling; query and row processing errors are propagated to the caller
 
 ## Bulk updates

--- a/lib/simple_query/stream/postgres_stream.rb
+++ b/lib/simple_query/stream/postgres_stream.rb
@@ -12,10 +12,14 @@ module SimpleQuery
         conn = ActiveRecord::Base.connection.raw_connection
         cursor_name = "simple_query_cursor_#{object_id}"
 
+        cursor_declared = false
+        success_path_close_started = false
+
         begin
           conn.exec("BEGIN")
           declare_sql = "DECLARE #{cursor_name} NO SCROLL CURSOR FOR #{select_sql}"
           conn.exec(declare_sql)
+          cursor_declared = true
 
           loop do
             res = conn.exec("FETCH #{batch_size} FROM #{cursor_name}")
@@ -27,15 +31,13 @@ module SimpleQuery
             end
           end
 
+          success_path_close_started = true
           conn.exec("CLOSE #{cursor_name}")
           conn.exec("COMMIT")
-        rescue StandardError => e
-          begin
-            conn.exec("ROLLBACK")
-          rescue StandardError
-            nil
-          end
-          raise e
+        rescue StandardError
+          close_postgres_stream_cursor(conn, cursor_name) if cursor_declared && !success_path_close_started
+          rollback_postgres_stream_transaction(conn)
+          raise
         end
       end
       # rubocop:enable Metrics/MethodLength
@@ -46,6 +48,18 @@ module SimpleQuery
         return if batch_size.is_a?(Integer) && batch_size.positive?
 
         raise ArgumentError, "stream_each batch_size must be a positive Integer"
+      end
+
+      def close_postgres_stream_cursor(conn, cursor_name)
+        conn.exec("CLOSE #{cursor_name}")
+      rescue StandardError
+        nil
+      end
+
+      def rollback_postgres_stream_transaction(conn)
+        conn.exec("ROLLBACK")
+      rescue StandardError
+        nil
       end
 
       def build_row_object(pg_row)

--- a/lib/simple_query/stream/postgres_stream.rb
+++ b/lib/simple_query/stream/postgres_stream.rb
@@ -13,7 +13,7 @@ module SimpleQuery
         cursor_name = "simple_query_cursor_#{object_id}"
 
         cursor_declared = false
-        success_path_close_started = false
+        cursor_close_started = false
 
         begin
           conn.exec("BEGIN")
@@ -31,11 +31,11 @@ module SimpleQuery
             end
           end
 
-          success_path_close_started = true
+          cursor_close_started = true
           conn.exec("CLOSE #{cursor_name}")
           conn.exec("COMMIT")
         rescue StandardError
-          close_postgres_stream_cursor(conn, cursor_name) if cursor_declared && !success_path_close_started
+          close_postgres_stream_cursor(conn, cursor_name) if cursor_declared && !cursor_close_started
           rollback_postgres_stream_transaction(conn)
           raise
         end

--- a/spec/simple_query/stream/postgres_stream_spec.rb
+++ b/spec/simple_query/stream/postgres_stream_spec.rb
@@ -62,6 +62,27 @@ RSpec.describe SimpleQuery::Stream::PostgresStream do
       end.to raise_error(ArgumentError, "stream_each batch_size must be a positive Integer")
     end
 
+    it "rolls back and propagates a successful-path cursor close failure" do
+      expect(conn).to receive(:exec).with("BEGIN").ordered
+      expect(conn).to receive(:exec)
+        .with("DECLARE simple_query_cursor_#{builder.object_id} NO SCROLL CURSOR FOR SELECT * FROM users")
+        .ordered
+
+      fetch_result = double("PGResult", ntuples: 0)
+      expect(conn).to receive(:exec).with("FETCH 100 FROM simple_query_cursor_#{builder.object_id}")
+                                    .ordered.and_return(fetch_result)
+      expect(conn).to receive(:exec).with("CLOSE simple_query_cursor_#{builder.object_id}")
+                                    .ordered.and_raise("close failed")
+      expect(conn).to receive(:exec).with("ROLLBACK").ordered
+      expect(conn).not_to receive(:exec).with("COMMIT")
+
+      allow(ActiveRecord::Base).to receive_message_chain(:connection, :raw_connection).and_return(conn)
+
+      expect do
+        builder.stream_each_postgres(100) { |_record| }
+      end.to raise_error("close failed")
+    end
+
     it "rolls back if declaring the cursor fails" do
       expect(conn).to receive(:exec).with("BEGIN").ordered
       expect(conn).to receive(:exec).with(/DECLARE simple_query_cursor_\d+ NO SCROLL CURSOR FOR SELECT \* FROM users/)
@@ -75,16 +96,16 @@ RSpec.describe SimpleQuery::Stream::PostgresStream do
       end.to raise_error("Boom!")
     end
 
-    it "rolls back if fetching from the cursor fails" do
+    it "closes the cursor and rolls back if fetching from the cursor fails" do
       expect(conn).to receive(:exec).with("BEGIN").ordered
       expect(conn).to receive(:exec)
         .with("DECLARE simple_query_cursor_#{builder.object_id} NO SCROLL CURSOR FOR SELECT * FROM users")
         .ordered
       expect(conn).to receive(:exec).with("FETCH 100 FROM simple_query_cursor_#{builder.object_id}")
-                                    .and_raise("fetch failed")
-      expect(conn).not_to receive(:exec).with("CLOSE simple_query_cursor_#{builder.object_id}")
+                                    .ordered.and_raise("fetch failed")
+      expect(conn).to receive(:exec).with("CLOSE simple_query_cursor_#{builder.object_id}").ordered
+      expect(conn).to receive(:exec).with("ROLLBACK").ordered
       expect(conn).not_to receive(:exec).with("COMMIT")
-      expect(conn).to receive(:exec).with("ROLLBACK")
 
       allow(ActiveRecord::Base).to receive_message_chain(:connection, :raw_connection).and_return(conn)
 
@@ -93,7 +114,26 @@ RSpec.describe SimpleQuery::Stream::PostgresStream do
       end.to raise_error("fetch failed")
     end
 
-    it "rolls back and preserves the original error if row processing fails" do
+    it "ignores cleanup close failures and preserves the original fetch error" do
+      expect(conn).to receive(:exec).with("BEGIN").ordered
+      expect(conn).to receive(:exec)
+        .with("DECLARE simple_query_cursor_#{builder.object_id} NO SCROLL CURSOR FOR SELECT * FROM users")
+        .ordered
+      expect(conn).to receive(:exec).with("FETCH 100 FROM simple_query_cursor_#{builder.object_id}")
+                                    .ordered.and_raise("fetch failed")
+      expect(conn).to receive(:exec).with("CLOSE simple_query_cursor_#{builder.object_id}")
+                                    .ordered.and_raise("close failed")
+      expect(conn).to receive(:exec).with("ROLLBACK").ordered
+      expect(conn).not_to receive(:exec).with("COMMIT")
+
+      allow(ActiveRecord::Base).to receive_message_chain(:connection, :raw_connection).and_return(conn)
+
+      expect do
+        builder.stream_each_postgres(100) { |_record| }
+      end.to raise_error("fetch failed")
+    end
+
+    it "closes the cursor, rolls back, and preserves the original error if row processing fails" do
       expect(conn).to receive(:exec).with("BEGIN").ordered
       expect(conn).to receive(:exec)
         .with("DECLARE simple_query_cursor_#{builder.object_id} NO SCROLL CURSOR FOR SELECT * FROM users")
@@ -103,10 +143,10 @@ RSpec.describe SimpleQuery::Stream::PostgresStream do
       allow(fetch_result).to receive(:each).and_yield("row1")
 
       expect(conn).to receive(:exec).with("FETCH 100 FROM simple_query_cursor_#{builder.object_id}")
-                                    .and_return(fetch_result)
-      expect(conn).not_to receive(:exec).with("CLOSE simple_query_cursor_#{builder.object_id}")
+                                    .ordered.and_return(fetch_result)
+      expect(conn).to receive(:exec).with("CLOSE simple_query_cursor_#{builder.object_id}").ordered
+      expect(conn).to receive(:exec).with("ROLLBACK").ordered
       expect(conn).not_to receive(:exec).with("COMMIT")
-      expect(conn).to receive(:exec).with("ROLLBACK")
 
       allow(ActiveRecord::Base).to receive_message_chain(:connection, :raw_connection).and_return(conn)
 


### PR DESCRIPTION
## Summary
PostgreSQL streaming now performs more careful cursor cleanup when a stream fails after the cursor has been declared. Row-processing failures close the cursor before rollback, fetch failures attempt cursor cleanup before rollback, and the original error remains visible to callers.

## Changes
- Tracks whether the PostgreSQL stream cursor has been declared before rescue cleanup runs.
- Adds cleanup paths that avoid masking the original fetch or row-processing error.
- Preserves successful-path close failure behavior by rolling back and propagating the close error.
- Updates streaming failure documentation and the changelog.

## Test plan
- Ruby syntax checks passed for the changed stream implementation and spec file.
- Whitespace diff check passed.
- GitHub Actions passed across the PostgreSQL and MySQL ActiveRecord matrix.
