### PR TITLE
test: document MySQL streaming batch contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,8 @@ end
 
 Adapter behavior:
 
-- PostgreSQL: uses a server-side cursor with `DECLARE` / `FETCH`; `batch_size` controls the number of rows fetched per cursor read
-- MySQL: uses `mysql2` streaming with `stream: true`, `cache_rows: false`, and `as: :hash`; `batch_size` is accepted by the public API but does not control MySQL batching
+- PostgreSQL: uses a server-side cursor with `DECLARE` / `FETCH`; `batch_size` must be a positive integer and controls the number of rows fetched per cursor read
+- MySQL: uses `mysql2` streaming with `stream: true`, `cache_rows: false`, and `as: :hash`; `batch_size` is validated as a positive integer for API symmetry, but mysql2 streams rows directly and does not expose a SimpleQuery-controlled batch size
 - Other adapters: `stream_each` raises `SimpleQuery::UnsupportedAdapterError` with the current adapter name
 
 Failure behavior:

--- a/spec/simple_query/builder_spec.rb
+++ b/spec/simple_query/builder_spec.rb
@@ -831,6 +831,24 @@ RSpec.describe SimpleQuery::Builder do
         expect(builder).to receive(:stream_each_mysql).and_return(nil)
         builder.stream_each { |row| }
       end
+
+      it "accepts a positive batch size without passing it to the mysql2 streaming path" do
+        builder = described_class.new(User)
+        allow(ActiveRecord::Base.connection).to receive(:adapter_name).and_return("MySQL")
+
+        expect(builder).to receive(:stream_each_mysql).with(no_args).and_return(nil)
+        builder.stream_each(batch_size: 500) { |_row| }
+      end
+
+      it "rejects invalid batch sizes before starting mysql2 streaming" do
+        builder = described_class.new(User)
+        allow(ActiveRecord::Base.connection).to receive(:adapter_name).and_return("MySQL")
+
+        expect(builder).not_to receive(:stream_each_mysql)
+        expect do
+          builder.stream_each(batch_size: "500") { |_row| }
+        end.to raise_error(ArgumentError, "stream_each batch_size must be a positive Integer")
+      end
     end
 
     context "when adapter is neither" do


### PR DESCRIPTION
## Summary
Clarifies the MySQL `stream_each` batch-size contract and adds regression coverage for the dispatcher behavior. PostgreSQL uses `batch_size` to control cursor fetch size, while MySQL validates the same public option for API symmetry but relies on mysql2's direct row streaming.

## Changes
- Documents PostgreSQL and MySQL `batch_size` behavior in the streaming adapter notes.
- Adds builder specs showing MySQL accepts a valid `batch_size` without forwarding it to the mysql2 streaming helper.
- Adds coverage that invalid MySQL `batch_size` values are rejected before streaming starts.

## Test plan
- RSpec builder specs passed.
- Full RSpec suite passed.
- RuboCop passed.
- Independent review found no blocking findings.
