### PR TITLE
docs: clarify SQL safety examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project are documented in this file.
 - ActiveRecord 8.0 is now included in the PostgreSQL/MySQL CI matrix on Ruby 3.2.
 - ActiveRecord dependency bounds now allow the full 8.0 patch line while excluding 8.1 until it is tested.
 - `simple_scope` now rejects invalid scope bodies at definition time.
+- README safety guidance now gives explicit allowlist and placeholder examples for trusted SQL fragment escape hatches.
 
 ### Fixed
 - PostgreSQL `stream_each` now closes a declared cursor before rollback when row processing fails and attempts cursor cleanup before rollback on fetch failures.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,57 @@ User.simple_query
     .execute
 ```
 
-Raw SQL strings are an escape hatch for trusted, application-owned SQL only. If any value comes from a user, request, file, or external service, use hash, Arel, or placeholder conditions instead.
+Raw SQL strings are an escape hatch for trusted, application-owned SQL only. If any value comes from a user, request, file, or external service, use hash, Arel, or placeholder conditions instead. The checklist below shows the safer patterns to prefer when query inputs are dynamic.
+
+### SQL fragment safety checklist
+
+SimpleQuery intentionally accepts SQL fragments in places where ActiveRecord also leaves judgment to the application, such as raw `where` strings, string `select` values, and `custom_aggregation` expressions. Treat those fragments as trusted code, not as a templating surface for request data.
+
+Prefer these patterns for dynamic values:
+
+```ruby
+# Good: read dynamic values, then pass them separately so ActiveRecord quotes them.
+email = params.fetch(:email)
+User.simple_query
+    .where(["email = :email", { email: email }])
+    .execute
+
+# Good: escape wildcard characters before using LIKE, then bind the pattern.
+search = params.fetch(:search)
+escaped_search = ActiveRecord::Base.sanitize_sql_like(search)
+User.simple_query
+    .where(["name LIKE ?", "%#{escaped_search}%"])
+    .execute
+```
+
+Avoid interpolating untrusted values into SQL fragments:
+
+```ruby
+# Unsafe: request data is interpolated into a raw SQL string.
+User.simple_query
+    .where("email = '#{params[:email]}'")
+    .execute
+```
+
+Even with quotes around the value, interpolation is unsafe because an apostrophe or SQL fragment in the input can break out of the literal. Keep the SQL string static and pass values through placeholders instead. For `LIKE` queries, `sanitize_sql_like` only escapes wildcard characters; it does not replace placeholder binding.
+
+The same boundary applies outside `where`: keep selected expressions, ordering fragments, and custom aggregation SQL static and application-owned. When a user chooses a column, sort direction, or metric, map that input to a small allowlist before building the query:
+
+```ruby
+sort_columns = {
+  "name" => :name,
+  "created_at" => :created_at
+}
+sort_directions = {
+  "asc" => :asc,
+  "desc" => :desc
+}
+
+User.simple_query
+    .select(:id, :name, :email)
+    .order(sort_columns.fetch(params[:sort], :name) => sort_directions.fetch(params[:direction], :asc))
+    .execute
+```
 
 ## Joins
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ User.simple_query
     .where(["email = :email", { email: email }])
     .execute
 
-# Good: escape wildcard characters before using LIKE, then bind the pattern.
+# Good: bind LIKE values with placeholders. Escape wildcard characters when
+# `%` and `_` should be treated as literal search text instead of wildcards.
 search = params.fetch(:search)
 escaped_search = ActiveRecord::Base.sanitize_sql_like(search)
 User.simple_query
@@ -180,7 +181,7 @@ User.simple_query
     .execute
 ```
 
-Even with quotes around the value, interpolation is unsafe because an apostrophe or SQL fragment in the input can break out of the literal. Keep the SQL string static and pass values through placeholders instead. For `LIKE` queries, `sanitize_sql_like` only escapes wildcard characters; it does not replace placeholder binding.
+Even with quotes around the value, interpolation is unsafe because an apostrophe or SQL fragment in the input can break out of the literal. Keep the SQL string static and pass values through placeholders instead. For `LIKE` queries, `sanitize_sql_like` only changes matching semantics by escaping `%`, `_`, and the escape character itself; it is useful when those characters should be searched literally, but it does not replace placeholder binding.
 
 The same boundary applies outside `where`: keep selected expressions, ordering fragments, and custom aggregation SQL static and application-owned. When a user chooses a column, sort direction, or metric, map that input to a small allowlist before building the query:
 


### PR DESCRIPTION
## Summary
Clarifies SimpleQuery's SQL-fragment safety guidance so users can distinguish trusted escape hatches from dynamic query inputs. The README now shows placeholder-based conditions, escaped LIKE patterns, unsafe interpolation, and allowlist mapping for dynamic ordering choices.

## Changes
- Added a SQL fragment safety checklist to the README.
- Expanded examples for placeholder binding, LIKE wildcard escaping, raw SQL interpolation risks, and allowlisted sort inputs.
- Recorded the documentation update in the changelog.

## Test Plan
- Full RSpec suite passed.
- RuboCop passed with no offenses.
- Diff whitespace check passed.
