### PR TITLE
docs: clarify where safety examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project are documented in this file.
 - ActiveRecord dependency bounds now allow the full 8.0 patch line while excluding 8.1 until it is tested.
 - `simple_scope` now rejects invalid scope bodies at definition time.
 - README safety guidance now gives explicit allowlist and placeholder examples for trusted SQL fragment escape hatches.
+- README safety guidance now clarifies `LIKE` placeholder quoting, with specs documenting trusted raw `where` strings as escape hatches.
 
 ### Fixed
 - PostgreSQL `stream_each` now closes a declared cursor before rollback when row processing fails and attempts cursor cleanup before rollback on fetch failures.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ User.simple_query
     .execute
 ```
 
-Keep the SQL fragment itself static and pass dynamic values as positional or named placeholders. Do not interpolate request parameters, form values, or other untrusted input into the SQL string.
+Keep the SQL fragment itself static and pass dynamic values as positional or named placeholders so ActiveRecord quotes them as SQL data literals. Do not interpolate request parameters, form values, or other untrusted input into the SQL string.
 
 ### Raw SQL conditions
 
@@ -163,7 +163,7 @@ User.simple_query
     .where(["email = :email", { email: email }])
     .execute
 
-# Good: bind LIKE values with placeholders. Escape wildcard characters when
+# Good: quote LIKE values with placeholders. Escape wildcard characters when
 # `%` and `_` should be treated as literal search text instead of wildcards.
 search = params.fetch(:search)
 escaped_search = ActiveRecord::Base.sanitize_sql_like(search)
@@ -181,7 +181,7 @@ User.simple_query
     .execute
 ```
 
-Even with quotes around the value, interpolation is unsafe because an apostrophe or SQL fragment in the input can break out of the literal. Keep the SQL string static and pass values through placeholders instead. For `LIKE` queries, `sanitize_sql_like` only changes matching semantics by escaping `%`, `_`, and the escape character itself; it is useful when those characters should be searched literally, but it does not replace placeholder binding.
+Even with quotes around the value, interpolation is unsafe because an apostrophe or SQL fragment in the input can break out of the literal. Keep the SQL string static and pass values through placeholders so ActiveRecord quotes them as SQL data literals instead. For `LIKE` queries, `sanitize_sql_like` only changes matching semantics by escaping `%`, `_`, and the escape character itself; it is useful when those characters should be searched literally, but it does not replace placeholder quoting.
 
 The same boundary applies outside `where`: keep selected expressions, ordering fragments, and custom aggregation SQL static and application-owned. When a user chooses a column, sort direction, or metric, map that input to a small allowlist before building the query:
 
@@ -488,14 +488,19 @@ Use hash conditions for simple equality predicates and array placeholder conditi
 User.simple_query.where(email: params[:email]).execute
 
 # SQL fragments with external values should use ActiveRecord-style placeholders.
+query = params[:query].to_s
+escaped_query = ActiveRecord::Base.sanitize_sql_like(query)
+
 User.simple_query
-    .where(["name ILIKE ?", "%#{params[:query]}%"])
+    .where(["name ILIKE ?", "%#{escaped_query}%"])
     .execute
 
 User.simple_query
     .where(["email = :email", { email: params[:email] }])
     .execute
 ```
+
+Placeholders quote values as SQL data literals, while `sanitize_sql_like` makes `%` and `_` match literally in `LIKE` patterns; escaping the pattern does not replace placeholder quoting.
 
 Do not interpolate external values into raw strings:
 
@@ -517,7 +522,7 @@ Company.simple_query
        .execute
 ```
 
-Keep aliases, custom aggregation expressions, raw `select` strings, raw `where` strings, `having` expressions, and `group_concat` separators static or otherwise trusted. If a fragment must include external values, bind them before passing the query to SimpleQuery or express the condition with hash, Arel, or placeholder `where` syntax.
+Keep aliases, custom aggregation expressions, raw `select` strings, raw `where` strings, `having` expressions, and `group_concat` separators static or otherwise trusted. If a condition must include external values, express those values with hash, Arel, or placeholder `where` syntax instead of interpolating them into raw SQL fragments.
 
 ### Direct updates
 

--- a/spec/simple_query/clauses/where_clause_spec.rb
+++ b/spec/simple_query/clauses/where_clause_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe SimpleQuery::WhereClause do
       expect(where_clause.conditions.first.to_s).to include("users.deleted_at IS NULL")
     end
 
+    it "preserves string conditions as trusted raw SQL" do
+      condition = "users.deleted_at IS NULL OR users.admin = 1"
+
+      where_clause.add(condition)
+
+      expect(where_clause.conditions.size).to eq(1)
+      expect(where_clause.conditions.first).to be_a(Arel::Nodes::SqlLiteral)
+      expect(where_clause.conditions.first.to_s).to eq(condition)
+    end
+
     context "with placeholder arrays" do
       it "handles positional placeholders" do
         where_clause.add(["name LIKE ?", "%John%"])
@@ -38,6 +48,17 @@ RSpec.describe SimpleQuery::WhereClause do
         sql_node = where_clause.conditions.first
         expect(sql_node).to be_a(Arel::Nodes::SqlLiteral)
         expect(sql_node.to_s).to match(/name LIKE '%John%'/)
+      end
+
+      it "quotes SQL-like placeholder values as data" do
+        unsafe_value = "x' OR '1'='1"
+
+        where_clause.add(["name = ?", unsafe_value])
+        expect(where_clause.conditions.size).to eq(1)
+
+        sql_node = where_clause.conditions.first
+        expect(sql_node).to be_a(Arel::Nodes::SqlLiteral)
+        expect(sql_node.to_s).to eq("name = #{ActiveRecord::Base.connection.quote(unsafe_value)}")
       end
 
       it "handles named placeholders" do


### PR DESCRIPTION
## Summary
Clarifies the README safety guidance for dynamic `LIKE` filters and raw `where` SQL fragments. The documentation now shows user search text escaped with `sanitize_sql_like` before it is passed through placeholder syntax, and the specs document the boundary between placeholder values and trusted raw SQL strings.

## Changes
- Updated Safety Notes examples for literal `%` and `_` handling in `LIKE` patterns.
- Documented that placeholder values are quoted as SQL data literals rather than interpolated into raw SQL fragments.
- Added focused `WhereClause` specs for SQL-like placeholder values and trusted raw string conditions.
- Recorded the documentation/spec follow-up in the changelog.

## Test Plan
- `bundle exec rspec`
- `bundle exec rubocop`
- `git diff --check`
