### PR TITLE
test: include benchmark reproducibility metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 - README safety guidance now clarifies `LIKE` placeholder quoting, with specs documenting trusted raw `where` strings as escape hatches.
 - README benchmark guidance now shows how to capture reproducible benchmark JSON and environment metadata artifacts.
 - Benchmark harness regression specs now guard JSON artifact shape and environment config parsing.
+- Benchmark JSON metadata now includes Git revision, dirty-checkout state, Ruby platform, Bundler version, and exported `BENCHMARK_*` settings.
 
 ### Fixed
 - PostgreSQL `stream_each` now closes a declared cursor before rollback when row processing fails and attempts cursor cleanup before rollback on fetch failures.

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ bundle exec rake benchmark:reproducible > tmp/benchmarks/simple_query-reproducib
 ruby -rjson -e 'JSON.parse(File.read(ARGV.fetch(0)))' tmp/benchmarks/simple_query-reproducible.json
 ```
 
-Before sharing or comparing a result, record enough environment metadata to recreate the run. The benchmark JSON includes runtime and key dependency information, but it is also useful to save the exact repository revision, dirty-checkout status, Ruby version, Bundler version, platform, hardware notes, and any non-default exported `BENCHMARK_*` values used from the same shell session:
+Before sharing or comparing a result, record enough environment metadata to recreate the run. The benchmark JSON includes runtime details, key dependency versions, and exported `BENCHMARK_*` values. When the task runs from a Git checkout, it also includes the current Git revision and dirty-checkout status; otherwise those Git fields are `null`. It is still useful to save companion hardware notes and the short Git status from the same shell session:
 
 ```sh
 set -e
@@ -488,16 +488,11 @@ mkdir -p tmp/benchmarks
   echo "git_status_short_start"
   git status --short
   echo "git_status_short_end"
-  echo "ruby_version=$(ruby --version)"
-  echo "bundler_version=$(bundle --version)"
-  echo "ruby_platform=$(ruby -e 'puts RUBY_PLATFORM')"
-  echo "benchmark_environment_start"
-  env | grep '^BENCHMARK_' | sort || true
-  echo "benchmark_environment_end"
+  echo "hardware=$(uname -a)"
 } > tmp/benchmarks/simple_query-reproducible.metadata
 ```
 
-Use captured benchmark output only as a reproducibility artifact. Do not compare runs from different hardware, databases, Ruby versions, dependency sets, dataset sizes, warmup counts, run counts, or benchmark databases as if they were equivalent. Prefer comparing changes by rerunning the same command on the same machine from a clean checkout of each revision, and treat non-empty `git status --short` metadata as a signal that the run may not be reproducible from the recorded revision alone.
+Use captured benchmark output only as a reproducibility artifact. Do not compare runs from different hardware, databases, Ruby versions, dependency sets, dataset sizes, warmup counts, run counts, or benchmark databases as if they were equivalent. Prefer comparing changes by rerunning the same command on the same machine from a clean checkout of each revision, and treat non-empty `git status --short` metadata as a signal that the run may not be reproducible from the recorded revision alone. Scrub sensitive environment values before sharing artifacts if any `BENCHMARK_*` setting contains credentials, private paths, or hostnames.
 
 ## Safety notes
 

--- a/benchmark/simple_query_benchmark.rb
+++ b/benchmark/simple_query_benchmark.rb
@@ -2,7 +2,9 @@
 
 require "active_record"
 require "benchmark"
+require "bundler"
 require "json"
+require "open3"
 require "simple_query"
 require "simple_query/version"
 
@@ -114,14 +116,49 @@ module SimpleQueryBenchmark # rubocop:disable Metrics/ModuleLength
   def metadata(config)
     {
       ruby: RUBY_DESCRIPTION,
+      ruby_platform: RUBY_PLATFORM,
+      bundler: Bundler::VERSION,
       active_record: ActiveRecord::VERSION::STRING,
       simple_query: SimpleQuery::VERSION,
       adapter: ActiveRecord::Base.connection.adapter_name,
+      git_revision: git_revision,
+      git_dirty: git_dirty,
+      benchmark_environment: benchmark_environment,
       rows: config.fetch(:rows),
       runs: config.fetch(:runs),
       warmup: config.fetch(:warmup),
       database: config.fetch(:database)
     }
+  end
+
+  def git_revision
+    git_output("rev-parse", "HEAD")
+  end
+
+  def git_dirty
+    status = git_output("status", "--porcelain")
+    return nil if status.nil?
+
+    !status.empty?
+  end
+
+  def git_output(*arguments)
+    stdout, _stderr, status = Open3.capture3("git", *arguments, chdir: project_root)
+    return nil unless status.success?
+
+    stdout.strip
+  rescue Errno::ENOENT
+    nil
+  end
+
+  def project_root
+    File.expand_path("..", __dir__)
+  end
+
+  def benchmark_environment
+    ENV.select { |key, _value| key.start_with?("BENCHMARK_") }
+       .sort_by { |key, _value| key }
+       .to_h
   end
 
   def timing_results(config)

--- a/benchmark/simple_query_benchmark.rb
+++ b/benchmark/simple_query_benchmark.rb
@@ -147,7 +147,7 @@ module SimpleQueryBenchmark # rubocop:disable Metrics/ModuleLength
     return nil unless status.success?
 
     stdout.strip
-  rescue Errno::ENOENT
+  rescue SystemCallError
     nil
   end
 

--- a/spec/benchmark/simple_query_benchmark_spec.rb
+++ b/spec/benchmark/simple_query_benchmark_spec.rb
@@ -193,6 +193,12 @@ RSpec.describe "benchmark/simple_query_benchmark" do
 
       expect(SimpleQueryBenchmark.git_output("rev-parse", "HEAD")).to be_nil
     end
+
+    it "returns nil when git cannot be executed" do
+      allow(Open3).to receive(:capture3).and_raise(Errno::EACCES)
+
+      expect(SimpleQueryBenchmark.git_output("rev-parse", "HEAD")).to be_nil
+    end
   end
 
   describe "running the harness" do

--- a/spec/benchmark/simple_query_benchmark_spec.rb
+++ b/spec/benchmark/simple_query_benchmark_spec.rb
@@ -6,39 +6,20 @@ require "open3"
 require "stringio"
 
 RSpec.describe "benchmark/simple_query_benchmark" do
-  def benchmark_env_keys
-    [
-      "BENCHMARK_ROWS",
-      "BENCHMARK_RUNS",
-      "BENCHMARK_WARMUP",
-      "BENCHMARK_DATABASE"
-    ]
-  end
-
   def benchmark_path
     File.expand_path("../../benchmark/simple_query_benchmark.rb", __dir__)
   end
 
   def with_benchmark_env(values)
-    previous = benchmark_env_keys.to_h { |key| [key, ENV.fetch(key, nil)] }
+    previous = ENV.select { |key, _value| key.start_with?("BENCHMARK_") }
 
-    benchmark_env_keys.each do |key|
-      if values.key?(key)
-        ENV[key] = values[key]
-      else
-        ENV.delete(key)
-      end
-    end
+    ENV.delete_if { |key, _value| key.start_with?("BENCHMARK_") }
+    values.each { |key, value| ENV[key] = value }
 
     yield
   ensure
-    previous.each do |key, value|
-      if value.nil?
-        ENV.delete(key)
-      else
-        ENV[key] = value
-      end
-    end
+    ENV.delete_if { |key, _value| key.start_with?("BENCHMARK_") }
+    previous.each { |key, value| ENV[key] = value }
   end
 
   def valid_integer_env
@@ -152,6 +133,65 @@ RSpec.describe "benchmark/simple_query_benchmark" do
           end
         end
       end
+    end
+  end
+
+  describe ".metadata" do
+    before do
+      require benchmark_path
+    end
+
+    it "includes repository, runtime, and benchmark environment details" do
+      allow(SimpleQueryBenchmark).to receive(:git_revision).and_return("abc123")
+      allow(SimpleQueryBenchmark).to receive(:git_dirty).and_return(false)
+
+      with_benchmark_env(
+        "BENCHMARK_ROWS" => "12",
+        "BENCHMARK_RUNS" => "3",
+        "BENCHMARK_WARMUP" => "2",
+        "BENCHMARK_DATABASE" => "tmp/benchmark.sqlite3"
+      ) do
+        metadata = SimpleQueryBenchmark.metadata(
+          rows: 12,
+          runs: 3,
+          warmup: 2,
+          database: "tmp/benchmark.sqlite3"
+        )
+
+        expect(metadata).to include(
+          ruby: RUBY_DESCRIPTION,
+          ruby_platform: RUBY_PLATFORM,
+          bundler: Bundler::VERSION,
+          active_record: ActiveRecord::VERSION::STRING,
+          simple_query: SimpleQuery::VERSION,
+          adapter: ActiveRecord::Base.connection.adapter_name,
+          git_revision: "abc123",
+          git_dirty: false,
+          rows: 12,
+          runs: 3,
+          warmup: 2,
+          database: "tmp/benchmark.sqlite3"
+        )
+        expect(metadata.fetch(:benchmark_environment)).to eq(
+          "BENCHMARK_DATABASE" => "tmp/benchmark.sqlite3",
+          "BENCHMARK_ROWS" => "12",
+          "BENCHMARK_RUNS" => "3",
+          "BENCHMARK_WARMUP" => "2"
+        )
+      end
+    end
+
+    it "returns nil git values when repository metadata is unavailable" do
+      allow(SimpleQueryBenchmark).to receive(:git_output).and_return(nil)
+
+      expect(SimpleQueryBenchmark.git_revision).to be_nil
+      expect(SimpleQueryBenchmark.git_dirty).to be_nil
+    end
+
+    it "returns nil when the git executable is unavailable" do
+      allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+
+      expect(SimpleQueryBenchmark.git_output("rev-parse", "HEAD")).to be_nil
     end
   end
 


### PR DESCRIPTION
## Summary
Strengthens the reproducible benchmark harness by embedding the run context directly in the JSON artifact. Benchmark captures now carry the runtime, dependency, Git, and workload environment metadata needed to compare results responsibly.

## Changes
- Adds benchmark JSON metadata for Ruby platform, Bundler version, Git revision, dirty-checkout state, and exported benchmark settings.
- Handles missing or unavailable Git metadata by emitting null Git fields instead of failing the benchmark.
- Expands benchmark specs for metadata shape, environment isolation, and Git fallback behavior.
- Updates benchmark documentation and changelog guidance for reproducible artifact sharing.

## Test plan
- Benchmark metadata specs pass, including extra benchmark environment isolation.
- Full RSpec suite passes.
- RuboCop reports no offenses.
- Gem package build succeeds.
- Diff whitespace check passes.
